### PR TITLE
Add minimal CLI suitable for running the formatter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,14 @@
 version = 3
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "pactfmt"
 version = "0.1.0"
+dependencies = [
+ "glob",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+glob = "0.3.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,88 @@
-fn main() {
-    println!("Hello, world!");
+use std::env;
+use std::fs;
+use std::io::{self};
+use std::path::Path;
+use std::process;
+
+fn main() -> io::Result<()> {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() < 3 {
+        eprintln!("Usage: pactfmt <check|format> <glob-patterns>");
+        process::exit(1);
+    }
+
+    let command = &args[1];
+    let patterns = &args[2..];
+
+    match command.as_str() {
+        "check" => check(patterns),
+        "format" => format(patterns),
+        _ => {
+            eprintln!("Unknown command: {}", command);
+            process::exit(1);
+        }
+    }
 }
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
+fn check(patterns: &[String]) -> io::Result<()> {
+    let mut all_formatted = true;
+    for pattern in patterns {
+        for entry in glob::glob(pattern).expect("Failed to read glob pattern") {
+            match entry {
+                Ok(path) => match check_file(&path) {
+                    Ok(true) => (),
+                    Ok(false) => {
+                        println!("Would reformat {}", path.display());
+                        all_formatted = false;
+                    }
+                    Err(e) => eprintln!("Error checking {}: {}", path.display(), e),
+                },
+                Err(e) => eprintln!("Error: {}", e),
+            }
+        }
     }
+    if all_formatted {
+        println!("All files formatted.");
+    } else {
+        process::exit(1);
+    }
+    Ok(())
+}
+
+fn check_file(path: &Path) -> io::Result<bool> {
+    let content = fs::read_to_string(path)?;
+    let formatted = format_content(&content);
+    Ok(content == formatted)
+}
+
+fn format(patterns: &[String]) -> io::Result<()> {
+    for pattern in patterns {
+        for entry in glob::glob(pattern).expect("Failed to read glob pattern") {
+            match entry {
+                Ok(path) => {
+                    if let Err(e) = format_file(&path) {
+                        eprintln!("Error processing {}: {}", path.display(), e);
+                    }
+                }
+                Err(e) => eprintln!("Error: {}", e),
+            }
+        }
+    }
+    Ok(())
+}
+
+fn format_file(path: &Path) -> io::Result<()> {
+    let content = fs::read_to_string(path)?;
+    let formatted = format_content(&content);
+    if content != formatted {
+        fs::write(path, formatted)?;
+        println!("Reformatted {}", path.display());
+    }
+    Ok(())
+}
+
+fn format_content(content: &str) -> String {
+    // TODO: Unimplemented
+    content.to_string()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,12 @@
 use std::env;
+use std::error;
 use std::fs;
-use std::io::{self};
 use std::path::Path;
 use std::process;
 
-fn main() -> io::Result<()> {
+type Result<T> = std::result::Result<T, Box<dyn error::Error>>;
+
+fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
 
     if args.len() < 3 {
@@ -16,28 +18,28 @@ fn main() -> io::Result<()> {
     let patterns = &args[2..];
 
     match command.as_str() {
-        "check" => check(patterns),
-        "format" => format(patterns),
+        "check" => check(patterns)?,
+        "format" => format(patterns)?,
         _ => {
             eprintln!("Unknown command: {}", command);
             process::exit(1);
         }
     }
+
+    Ok(())
 }
 
-fn check(patterns: &[String]) -> io::Result<()> {
+fn check(patterns: &[String]) -> Result<()> {
     let mut all_formatted = true;
     for pattern in patterns {
-        for entry in glob::glob(pattern).expect("Failed to read glob pattern") {
+        for entry in glob::glob(pattern)? {
             match entry {
-                Ok(path) => match check_file(&path) {
-                    Ok(true) => (),
-                    Ok(false) => {
+                Ok(path) => {
+                    if !check_file(&path)? {
                         println!("Would reformat {}", path.display());
                         all_formatted = false;
                     }
-                    Err(e) => eprintln!("Error checking {}: {}", path.display(), e),
-                },
+                }
                 Err(e) => eprintln!("Error: {}", e),
             }
         }
@@ -50,15 +52,15 @@ fn check(patterns: &[String]) -> io::Result<()> {
     Ok(())
 }
 
-fn check_file(path: &Path) -> io::Result<bool> {
+fn check_file(path: &Path) -> Result<bool> {
     let content = fs::read_to_string(path)?;
     let formatted = format_content(&content);
     Ok(content == formatted)
 }
 
-fn format(patterns: &[String]) -> io::Result<()> {
+fn format(patterns: &[String]) -> Result<()> {
     for pattern in patterns {
-        for entry in glob::glob(pattern).expect("Failed to read glob pattern") {
+        for entry in glob::glob(pattern)? {
             match entry {
                 Ok(path) => {
                     if let Err(e) = format_file(&path) {
@@ -72,7 +74,7 @@ fn format(patterns: &[String]) -> io::Result<()> {
     Ok(())
 }
 
-fn format_file(path: &Path) -> io::Result<()> {
+fn format_file(path: &Path) -> Result<()> {
     let content = fs::read_to_string(path)?;
     let formatted = format_content(&content);
     if content != formatted {


### PR DESCRIPTION
Adds a basic CLI we can use to run the formatter during development. I've kept dependencies minimal until we know exactly what the CLI should do.