### PR TITLE
Add lexer implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,100 @@
 version = 3
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "logos"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161971eb88a0da7ae0c333e1063467c5b5727e7fb6b710b8db4814eade3a42e8"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e31badd9de5131fdf4921f6473d457e3dd85b11b7f091ceb50e4df7c3eeb12a"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "syn",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c2a69b3eb68d5bd595107c9ee58d7e07fe2bb5e360cc85b0f084dedac80de0a"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "pactfmt"
 version = "0.1.0"
+dependencies = [
+ "logos",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
+name = "syn"
+version = "2.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+logos = "0.14.0"

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -266,7 +266,7 @@ mod tests {
     #[test]
     fn test_comment() {
         assert_eq!(
-            lex_ok("; This is a comment\n; With a trailing newline\n\n"),
+            lex_ok("; This is a comment; it includes an extra semicolon.\n; This one has a trailing newline\n\n"),
             vec![Token::Comment, Token::Comment, Token::Newline]
         );
         assert_eq!(lex_ok("; Comment without newline"), vec![Token::Comment]);

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -59,10 +59,113 @@ pub enum Token {
     )]
     Ident,
 
-    #[regex(r";[^\n]*\n?")]
+    #[token("let*")]
+    LetRec,
+
+    #[token("let")]
+    Let,
+
+    #[token("if")]
+    If,
+
+    #[token("defun")]
+    Defun,
+
+    #[token("defcap")]
+    DefCap,
+
+    #[token("defconst")]
+    DefConst,
+
+    #[token("defschema")]
+    DefSchema,
+
+    #[token("deftable")]
+    DefTable,
+
+    #[token("defpact")]
+    DefPact,
+
+    #[token("interface")]
+    Interface,
+
+    #[token("module")]
+    Module,
+
+    #[token("bless")]
+    Bless,
+
+    #[token("implements")]
+    Implements,
+
+    #[token("use")]
+    Use,
+
+    #[token("lambda")]
+    Lambda,
+
+    #[token("and")]
+    And,
+
+    #[token("or")]
+    Or,
+
+    #[token("load")]
+    Load,
+
+    #[token("@doc")]
+    DocAnn,
+
+    #[token("@model")]
+    ModelAnn,
+
+    #[token("@event")]
+    EventAnn,
+
+    #[token("@managed")]
+    ManagedAnn,
+
+    #[token("step-with-rollback")]
+    StepWithRollback,
+
+    #[token("enforce")]
+    Enforce,
+
+    #[token("enforce-one")]
+    EnforceOne,
+
+    #[token("step")]
+    Step,
+
+    #[token("with-capability")]
+    WithCapability,
+
+    #[token("create-user-guard")]
+    CreateUserGuard,
+
+    #[token("try")]
+    Try,
+
+    #[token("do")]
+    Do,
+
+    #[token("suspend")]
+    Suspend,
+
+    // Comments are a semicolon followed by a sequence of characters terminated by a newline. The
+    // newline is consumed and dropped from the token stream.
+    #[regex(r";[^\n]*", callback = |lex| {
+        if lex.remainder().starts_with('\n') {
+            lex.bump(1);
+        }
+        Some(())
+    })]
     Comment,
 
-    #[regex(r"[ \t\n\r]+", logos::skip)]
+    #[token("\n")]
+    Newline,
+
+    #[regex(r"[ \t\r]+", logos::skip)]
     Whitespace,
 }
 
@@ -163,8 +266,8 @@ mod tests {
     #[test]
     fn test_comment() {
         assert_eq!(
-            lex_ok("; This is a comment\n; With a newline"),
-            vec![Token::Comment, Token::Comment]
+            lex_ok("; This is a comment\n; With a trailing newline\n\n"),
+            vec![Token::Comment, Token::Comment, Token::Newline]
         );
         assert_eq!(lex_ok("; Comment without newline"), vec![Token::Comment]);
     }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,0 +1,222 @@
+use logos::Logos;
+
+#[derive(Logos, Debug, PartialEq, Clone)]
+pub enum Token {
+    #[token("(")]
+    LeftParen,
+
+    #[token(")")]
+    RightParen,
+
+    #[token("{")]
+    LeftBrace,
+
+    #[token("}")]
+    RightBrace,
+
+    #[token("[")]
+    LeftBracket,
+
+    #[token("]")]
+    RightBracket,
+
+    #[token(":=")]
+    ColonEquals,
+
+    #[token(":")]
+    Colon,
+
+    #[token("::")]
+    DoubleColon,
+
+    #[token(",")]
+    Comma,
+
+    #[token(".")]
+    Dot,
+
+    #[token("true")]
+    #[token("false")]
+    Boolean,
+
+    #[regex(r"-?[0-9]+")]
+    Integer,
+
+    #[regex(r"-?[0-9]+\.[0-9]+")]
+    Decimal,
+
+    #[regex(r#""(?:[^"\\]|\\.|\\[\n\r][^"])*""#)]
+    String,
+
+    #[regex(r#"'[^\s\t\n\r,:.\"\'\[\]()]+"#)]
+    Symbol,
+
+    // NOTE: This includes ASCII characters, but technically it's possible for Pact source
+    // code to include arbitrary unicode.
+    #[regex(
+        r#"[a-zA-Z%#+\-_&$@<>=?*!|/][a-zA-Z0-9%#+\-_&$@<>=?*!|/]*"#,
+        priority = 1
+    )]
+    Ident,
+
+    #[regex(r";[^\n]*\n?")]
+    Comment,
+
+    #[regex(r"[ \t\n\r]+", logos::skip)]
+    Whitespace,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lex(input: &str) -> Vec<Result<Token, ()>> {
+        Token::lexer(input).collect()
+    }
+
+    fn lex_ok(input: &str) -> Vec<Token> {
+        lex(input).into_iter().filter_map(Result::ok).collect()
+    }
+
+    #[test]
+    fn test_punctuation() {
+        assert_eq!(
+            lex_ok("( ) { } [ ]"),
+            vec![
+                Token::LeftParen,
+                Token::RightParen,
+                Token::LeftBrace,
+                Token::RightBrace,
+                Token::LeftBracket,
+                Token::RightBracket
+            ]
+        );
+        assert_eq!(
+            lex_ok(":= : :: , ."),
+            vec![
+                Token::ColonEquals,
+                Token::Colon,
+                Token::DoubleColon,
+                Token::Comma,
+                Token::Dot
+            ]
+        );
+    }
+
+    #[test]
+    fn test_boolean() {
+        assert_eq!(lex_ok("true false"), vec![Token::Boolean, Token::Boolean]);
+        assert_eq!(lex_ok("TRUE FALSE"), vec![Token::Ident, Token::Ident]); // Should be identifiers, not booleans
+    }
+
+    #[test]
+    fn test_numbers() {
+        assert_eq!(
+            lex_ok("0 42 -17"),
+            vec![Token::Integer, Token::Integer, Token::Integer]
+        );
+        assert_eq!(
+            lex_ok("3.14 -0.5 42.0"),
+            vec![Token::Decimal, Token::Decimal, Token::Decimal]
+        );
+        assert_eq!(
+            lex_ok("3. .14"),
+            vec![Token::Integer, Token::Dot, Token::Dot, Token::Integer]
+        ); // Not valid decimals
+    }
+
+    #[test]
+    fn test_string() {
+        assert_eq!(lex_ok(r#""Hello, world!""#), vec![Token::String]);
+        assert_eq!(
+            lex_ok(r#""Escaped \"quotes\" and \n newlines""#),
+            vec![Token::String]
+        );
+        assert_eq!(lex_ok("\"Multi-line \\\nstring\""), vec![Token::String]);
+        assert!(lex("\"Unterminated string").iter().any(|r| r.is_err()));
+    }
+
+    #[test]
+    fn test_symbol() {
+        assert_eq!(lex_ok("'symbol"), vec![Token::Symbol]);
+        assert_eq!(lex_ok("'complex-symbol123"), vec![Token::Symbol]);
+        assert_eq!(lex_ok("'invalid symbol"), vec![Token::Symbol, Token::Ident]);
+        // Space terminates the symbol
+    }
+
+    #[test]
+    fn test_identifier() {
+        assert_eq!(
+            lex_ok("variable _underscore $dollar"),
+            vec![Token::Ident, Token::Ident, Token::Ident]
+        );
+        assert_eq!(
+            lex_ok("!important? ++increment"),
+            vec![Token::Ident, Token::Ident]
+        );
+        assert_eq!(
+            lex_ok("@at-sign %percent"),
+            vec![Token::Ident, Token::Ident]
+        );
+    }
+
+    #[test]
+    fn test_comment() {
+        assert_eq!(
+            lex_ok("; This is a comment\n; With a newline"),
+            vec![Token::Comment, Token::Comment]
+        );
+        assert_eq!(lex_ok("; Comment without newline"), vec![Token::Comment]);
+    }
+
+    #[test]
+    fn test_mixed_tokens() {
+        let input = r#"
+        (module example GOVERNANCE
+          (defcap GOVERNANCE ()
+            (enforce-keyset 'admin-keyset))
+
+          (defun square (x:integer)
+            (* x x))
+
+          (defun sum-squares (a:integer b:integer)
+            (let ((a-squared (square a))
+                  (b-squared (square b)))
+              (+ a-squared b-squared)))
+
+          ; This is a comment
+          (defun process-data (amount:decimal)
+            @doc "Process data with a given amount"
+            @model [(property (> amount 0.0))]
+            (enforce (> amount 0.0) "Amount must be positive")
+            (with-read accounts 'user-account { "balance" := bal }
+              (enforce (<= amount bal) "Insufficient funds")
+              (update accounts 'user-account
+                { "balance": (- bal amount) })))
+        )
+        "#;
+
+        let tokens = lex_ok(input);
+
+        // Tokens that should be present
+        assert!(tokens.contains(&Token::LeftBracket));
+        assert!(tokens.contains(&Token::RightBracket));
+        assert!(tokens.contains(&Token::LeftParen));
+        assert!(tokens.contains(&Token::RightParen));
+        assert!(tokens.contains(&Token::Ident)); // e.g., module, defcap, defun, enforce-keyset, etc.
+        assert!(tokens.contains(&Token::Symbol)); // e.g., 'admin-keyset, 'user-account
+        assert!(tokens.contains(&Token::String)); // e.g., "Process data with a given amount"
+        assert!(tokens.contains(&Token::Decimal)); // e.g., 0.0
+        assert!(tokens.contains(&Token::Colon)); // Used in type annotations like x:integer
+        assert!(tokens.contains(&Token::Comment)); // The line with ; This is a comment
+        assert!(tokens.contains(&Token::LeftBrace)); // Used in { "balance" := bal }
+        assert!(tokens.contains(&Token::RightBrace));
+        assert!(tokens.contains(&Token::ColonEquals)); // Used in := for binding
+
+        // Tokens that should not be present
+        assert!(!tokens.contains(&Token::DoubleColon));
+        assert!(!tokens.contains(&Token::Comma));
+        assert!(!tokens.contains(&Token::Dot));
+        assert!(!tokens.contains(&Token::Boolean));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,5 @@
+pub mod lexer;
+
 fn main() {
     println!("Hello, world!");
-}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
-    }
 }


### PR DESCRIPTION
For a lexer I've chosen to go with [logos](https://github.com/maciejhirsz/logos), as it's a standard and very fast lexer and our lexing should be suitable with regex alone.

I went back and forth over how detailed we should get in our lexer — do we bother picking up keywords here, for example? — but I eventually opted to keep it fairly thin, just basic syntax. I lex comments but ignore whitespace — potentially in the future we'll want to include whitespace so we can give authors a bit of control over the separation of blocks of code.

I've included some basic tests as well. I don't really know how Rust projects typically structure their tests so I just kept them in the lexer; I'm happy to move them elsewhere.

I'm considering this lexer a first pass rather than our forever choice but it at least gives us a foundation to stand on.