### PR TITLE
Add trailing comment handling to parser

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -7,7 +7,7 @@ pub enum Spacing {
     Comment(String),
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct SourceToken<T> {
     pub leading: Vec<Spacing>,
     pub value: T,

--- a/src/snapshots/pactfmt__format__tests__defun_multiline-2.snap
+++ b/src/snapshots/pactfmt__format__tests__defun_multiline-2.snap
@@ -13,8 +13,7 @@ expression: doc_narrow.pretty(20)
   [
     "Write"
     (write y 1.0)
-    "definitely"
-    ; hmm
+    "definitely" ; hmm
     "succeeded"
   ]
 )

--- a/src/snapshots/pactfmt__format__tests__defun_multiline.snap
+++ b/src/snapshots/pactfmt__format__tests__defun_multiline.snap
@@ -7,8 +7,7 @@ expression: doc_wide.pretty(80)
   [
     "Write"
     (write y 1.0)
-    "definitely"
-    ; hmm
+    "definitely" ; hmm
     "succeeded"
   ]
 )


### PR DESCRIPTION
The format syntax tree is now able to handle trailing spacing, but the parser was not updated in #5. This change adds trailing comment handling to the parser and simplifies the CST a bit more using the `SourceToken` type. You can see the effect in the defun_multiline formatter, where we have a trailing comment on a member of the list.