### PR TITLE
Add ungrammar for Pact

### DIFF
--- a/crates/syntax/src/pact.ungram
+++ b/crates/syntax/src/pact.ungram
@@ -78,7 +78,7 @@ Def =
   Defun     // Function definition - defines a named function with parameters and body
 | DefConst  // Constant definition - defines a named constant value
 | DefCap    // Capability definition - defines an access control mechanism
-| DefSchema // Schema definition - defines a data structure schema
+| DefSchema // Schema definition - defines a new type
 | DefTable  // Table definition - defines a database table with a schema
 | DefPact   // Pact (multi-step transaction) definition - defines a cross-chain transaction
 
@@ -87,7 +87,6 @@ Def =
 Defun = '(' 'defun' name:'ident' TypeAnn? '(' Arg* ')' Documentation? Expr* ')'
 
 // Constant definition - defines a named constant value
-// Constants are evaluated once at module load time
 DefConst = '(' 'defconst' name:'ident' TypeAnn? Expr Documentation? ')'
 
 // Capability definition - defines a capability (access control mechanism)
@@ -96,12 +95,10 @@ DefConst = '(' 'defconst' name:'ident' TypeAnn? Expr Documentation? ')'
 DefCap = '(' 'defcap' name:'ident' TypeAnn? '(' Arg* ')' Documentation? CapMeta* Expr* ')'
 
 // Schema definition - defines a data structure schema (like a record type)
-// Schemas define the structure of data stored in tables and passed between functions
 DefSchema = '(' 'defschema' name:'ident' Documentation? SchemaArg* ')'
 
 // Table definition - defines a database table with a schema
-// Tables store persistent data in the blockchain
-DefTable = '(' 'deftable' name:'ident' ':' '{' schema:ParsedName '}' DocString? ')'
+DefTable = '(' 'deftable' name:'ident' ':' '{' schema:ParsedName '}' (DocString | Doc)? ')'
 
 // Pact definition - defines a multi-step transaction
 // Used for cross-chain transactions and complex multi-stage operations
@@ -110,9 +107,9 @@ DefPact = '(' 'defpact' name:'ident' TypeAnn? '(' Arg* ')' Documentation? PactSt
 // Pact steps - individual steps in a multi-step transaction
 // Steps can be executed across different chains and transactions
 PactStep =
-  '(' 'step' entity:ParsedName? body:Expr Model? ')'                             // Regular step
-| '(' 'step-with-rollback' entity:ParsedName? body:Expr rollback:Expr Model? ')' // Step with rollback handler
-| '(' 'resume' binding:Binding body:Expr* ')'                              // Resume step with binding to access yielded values from previous step
+  '(' 'step' entity:ParsedName? body:Expr Model? ')'
+| '(' 'step-with-rollback' entity:ParsedName? body:Expr rollback:Expr Model? ')'
+| '(' 'resume' binding:Binding body:Expr* ')'
 
 // Interface definitions - definitions that can appear in an interface
 // These provide signatures without implementations
@@ -156,7 +153,7 @@ Type =
 
 // Primitive types
 PrimType =
-  'int'
+  'integer'
 | 'decimal'
 | 'bool'
 | 'string'

--- a/crates/syntax/src/pact.ungram
+++ b/crates/syntax/src/pact.ungram
@@ -1,0 +1,312 @@
+// This grammar specifies the structure of Pact 5's concrete syntax tree. Note: This is
+// not a parsing grammar but describes the structure of the syntax tree. This covers both
+// regular Pact source files and REPL files. REPL-specific commands like env-data,
+// env-keys, begin-tx, etc. are syntactically just function applications and are covered
+// by the Expr construct.
+
+Program = TopLevel*
+
+// For regular Pact source files
+TopLevel =
+  Module      // Module definition with functions, capabilities, etc.
+| Interface   // Interface definition (similar to a module but only signatures)
+| Expr        // Top-level expression
+| Use         // Import statement (brings definitions from other modules into scope)
+
+// Module definition - the primary organizational unit in Pact
+// Contains definitions, imports, and other declarations
+Module = '(' 'module' name:'ident' gov:Governance Documentation? ExternalDecl* Def* ')'
+
+// Interface definition - defines a contract that modules can implement
+// Interfaces contain function signatures, constants, and schemas but no implementations
+Interface = '(' 'interface' name:'ident' Documentation? (Use | IfDef)* ')'
+
+// Governance models - specifies how a module is governed
+Governance =
+  StringOrSymbol  // Keyset-based governance (keyset name as string)
+| 'ident'         // Capability-based governance (capability name)
+
+// Documentation - either a docstring OR annotations, but not both
+// Provides information about the purpose and usage of definitions
+Documentation =
+  DocString
+| DefAnns
+
+// A simple docstring (a bare string at the beginning of a definition)
+DocString = StringLiteral
+
+// Definition annotations - can have @doc, @model, or both
+DefAnns =
+  Doc Model?
+| Model Doc?
+
+// Documentation annotation - @doc annotation
+Doc = '@doc' StringLiteral
+
+// Model annotation for formal verification
+// Contains a list of property expressions enclosed in square brackets
+// Used to specify invariants and properties for formal verification
+Model = '@model' '[' PropertyExpr* ']'
+
+// External declarations - declarations that reference things outside the module
+// These establish relationships with other modules and interfaces
+ExternalDecl =
+  Use
+| Implements
+| Bless
+
+// Import declaration - brings definitions from other modules into scope
+// The string is an optional hash for version pinning
+// The ImportList is an optional list of specific names to import
+Use = '(' 'import' QualifiedName StringLiteral? ImportList? ')'
+
+// Declare that this module implements an interface
+// This creates a contract that the module will provide all definitions required by the interface
+Implements = '(' 'implements' QualifiedName ')'
+
+// Bless a specific hash
+// Used for module versioning and upgrade paths
+Bless = '(' 'bless' StringLiteral ')'
+
+// List of specific names to import (when present, must have at least one)
+// Allows selective importing of definitions from a module
+ImportList = '[' 'ident'* ']'
+
+// Definitions - various types of definitions that can appear in a module
+// These are the primary building blocks of Pact modules
+Def =
+  Defun     // Function definition - defines a named function with parameters and body
+| DefConst  // Constant definition - defines a named constant value
+| DefCap    // Capability definition - defines an access control mechanism
+| DefSchema // Schema definition - defines a data structure schema
+| DefTable  // Table definition - defines a database table with a schema
+| DefPact   // Pact (multi-step transaction) definition - defines a cross-chain transaction
+
+// Function definition - defines a named function with parameters and body
+// Must have at least one expression in the body
+Defun = '(' 'defun' name:'ident' TypeAnn? '(' Arg* ')' Documentation? Expr* ')'
+
+// Constant definition - defines a named constant value
+// Constants are evaluated once at module load time
+DefConst = '(' 'defconst' name:'ident' TypeAnn? Expr Documentation? ')'
+
+// Capability definition - defines a capability (access control mechanism)
+// Must have at least one expression in the body
+// Can include metadata like @event and @managed
+DefCap = '(' 'defcap' name:'ident' TypeAnn? '(' Arg* ')' Documentation? CapMeta* Expr* ')'
+
+// Schema definition - defines a data structure schema (like a record type)
+// Schemas define the structure of data stored in tables and passed between functions
+DefSchema = '(' 'defschema' name:'ident' Documentation? SchemaArg* ')'
+
+// Table definition - defines a database table with a schema
+// Tables store persistent data in the blockchain
+DefTable = '(' 'deftable' name:'ident' ':' '{' schema:ParsedName '}' DocString? ')'
+
+// Pact definition - defines a multi-step transaction
+// Used for cross-chain transactions and complex multi-stage operations
+DefPact = '(' 'defpact' name:'ident' TypeAnn? '(' Arg* ')' Documentation? PactStep* ')'
+
+// Pact steps - individual steps in a multi-step transaction
+// Steps can be executed across different chains and transactions
+PactStep =
+  '(' 'step' entity:ParsedName? body:Expr Model? ')'                             // Regular step
+| '(' 'step-with-rollback' entity:ParsedName? body:Expr rollback:Expr Model? ')' // Step with rollback handler
+| '(' 'resume' binding:Binding body:Expr* ')'                              // Resume step with binding to access yielded values from previous step
+
+// Interface definitions - definitions that can appear in an interface
+// These provide signatures without implementations
+IfDef =
+  IfDefun
+| DefConst
+| IfDefCap
+| DefSchema
+| IfDefPact
+
+// Interface function definition - only signature, no implementation
+// Modules implementing the interface must provide matching implementations
+IfDefun = '(' 'defun' name:'ident' TypeAnn? '(' Arg* ')' Documentation? ')'
+
+// Interface capability definition - only signature, no implementation
+// Modules implementing the interface must provide matching capability definitions
+IfDefCap = '(' 'defcap' name:'ident' TypeAnn? '(' Arg* ')' Documentation? CapMeta* ')'
+
+// Interface pact definition - only signature, no implementation
+// Modules implementing the interface must provide matching pact definitions
+IfDefPact = '(' 'defpact' name:'ident' TypeAnn? '(' Arg* ')' Documentation? ')'
+
+// Capability metadata - additional information for capabilities
+// Controls how capabilities are managed and emitted as events
+CapMeta =
+  '@event' BoolLiteral?
+| '@managed'
+| '@managed' resource:ParsedName defun:'ident'
+
+// Arguments - function and other parameters
+// Arg = Function argument with optional type annotation
+Arg = name:'ident' TypeAnn?
+SchemaArg = name:'ident' TypeAnn  // Schema field (always has a type)
+
+Type =
+  PrimType                        // Primitive type
+| '[' Type ']'                    // List type
+| 'module' '{' QualifiedName* '}'       // Module reference type, comma separated
+| 'ident' '{' ParsedTyName '}'    // Object/Table type
+| '*'                             // Any type (wildcard)
+
+// Primitive types
+PrimType =
+  'int'
+| 'decimal'
+| 'bool'
+| 'string'
+| 'time'
+| 'unit'
+| 'guard'
+| 'list'
+| 'keyset'
+| 'object'
+| 'table'
+
+TypeAnn = ':' Type  // Type annotation
+
+// Expressions - the core computational elements
+Expr =
+  Var       // Variable reference
+| Let       // Let binding
+| Lam       // Lambda expression
+| App       // Function application
+| List      // List literal
+| Literal   // Constant/literal value
+| Object    // Object literal
+| Binding   // Binding form (for named arguments)
+
+// Variable reference - refers to a defined name
+Var =
+  BareName       // Bare name (local variable or function)
+| QualifiedName  // Qualified name (from another module)
+| ModRef         // Module reference (e.g., "ns::name")
+
+// Let binding - local variable definitions
+Let =
+  '(' 'let' '(' Binder* ')' Expr* ')'    // Regular let (parallel bindings)
+| '(' 'let*' '(' Binder* ')' Expr* ')'   // Sequential let (each binding sees previous ones)
+
+Binder = '(' name:'ident' TypeAnn? value:Expr ')'
+
+// Lambda expression - anonymous function
+Lam = '(' 'lambda' '(' Arg* ')' Expr* ')'
+
+// Function application - calling a function
+App = '(' fn:Expr args:Expr* bindings:BindingForm* ')'
+
+BindingForm = '{' BindPair* '}' // Named argument binding form: { "a" := 1, ... }
+
+// List literal - creates a list
+// Note: In Pact, list elements can be separated by spaces or commas
+List = '[' items:Expr* ']'
+
+// Object literal - creates an object/record
+Object = '{' fields:FieldPair* '}'
+FieldPair = key:StringOrSymbol ':' value:Expr
+
+// Binding form - for named arguments and destructuring
+Binding = '{' binds:BindPair* '}' body:Expr*
+
+// Binding pair - key-value pair in a binding form
+// The key is a string or symbol, followed by := and an argument (which may have a type annotation)
+BindPair = key:StringOrSymbol ':=' arg:Arg
+
+// Literals - actual literal values
+Literal =
+  IntLiteral       // Integer literal (e.g., 42)
+| DecimalLiteral   // Decimal literal (e.g., 3.14)
+| StringOrSymbol   // String or symbol literal
+| BoolLiteral      // Boolean literal (true/false)
+| '(' ')'          // Unit literal (empty value)
+
+// String representations in Pact
+StringOrSymbol =
+  StringLiteral    // Double-quoted string: "example"
+| SymbolLiteral    // Single-quoted symbol: 'example (no terminating quote)
+
+// String literal - double-quoted string
+StringLiteral = 'string'
+
+// Symbol literal - single-quoted identifier without terminating quote
+SymbolLiteral = 'tick'
+
+// Integer literal
+IntLiteral = 'int_number'
+
+// Decimal literal
+DecimalLiteral = 'decimal_number'
+
+// Boolean literals
+BoolLiteral =
+  'true'
+| 'false'
+
+// Names - references to defined entities
+// There are three types of names in Pact:
+// 1. Simple names (single identifier)
+// 2. Qualified names (dot-separated path)
+// 3. Module references (using :: operator)
+
+// A simple name - just a single identifier
+// Example: add
+BareName = 'ident'
+
+ModQual =
+  BareName                // Simple qualifier (e.g., "module")
+| BareName '.' ModQual    // Nested qualifier (e.g., "namespace.module")
+
+// A qualified name - contains at least one dot
+// In the parser, this is represented as a head and a ModQual
+// Example: my.module.function
+QualifiedName = head:BareName '.' ModQual
+
+// Module reference - references a name from a specific module using ::
+// Example: my.module::function
+ModRef = module:ModQual '::' name:'ident'
+
+// Name reference - used in most contexts where a name is needed
+ParsedName =
+  BareName       // Simple name (e.g., "add")
+| QualifiedName  // Qualified name (e.g., "math.add")
+| ModRef         // Module reference (e.g., "my.mod::name")
+
+// Type name reference - used specifically for type references
+// Cannot use module references for types
+ParsedTyName =
+  BareName       // Simple type name (e.g., "integer")
+| QualifiedName  // Qualified type name (e.g., "user.profile")
+
+// Property expressions - used in formal verification models
+// These form a specialized sub-language for expressing properties and invariants
+PropertyExpr =
+  ParsedName                     // Reference to a name
+| Literal                        // Literal value
+| '(' PropertyExpr* ')'          // Application of property expressions
+| '[' PropertyExpr* ']'          // List of property expressions
+| PropDefProperty                // Property definition (unique to property language)
+| PropLet                        // Let binding in property expressions
+| PropLam                        // Lambda expression in property expressions
+
+// Let binding in property expressions - uses 'let' keyword (not 'let*')
+// Similar to Let in the main language but specific to property expressions
+PropLet = '(' 'let' '(' PropBinder* ')' PropertyExpr* ')'
+
+// Binder for property let expressions
+PropBinder = '(' name:'ident' value:PropertyExpr ')'
+
+// Lambda expression in property expressions - uses 'lam' keyword (not 'lambda')
+// Similar to Lam in the main language but specific to property expressions
+PropLam = '(' 'lam' '(' Arg* ')' PropertyExpr* ')'
+
+// Property definition - defines a named property with optional arguments
+// Example: (defproperty conserves-mass (= (column-delta token-table 'balance) 0.0))
+// Example with args: (defproperty valid-account (account:string) (and (>= (length account) 3) (<= (length account) 256)))
+PropDefProperty = '(' 'defproperty' name:'ident' args:PropArgs? body:PropertyExpr ')'
+
+PropArgs = '(' Arg* ')'

--- a/crates/syntax/src/pact.ungram
+++ b/crates/syntax/src/pact.ungram
@@ -87,12 +87,12 @@ Def =
 Defun = '(' 'defun' name:'ident' TypeAnn? '(' Arg* ')' Documentation? Expr* ')'
 
 // Constant definition - defines a named constant value
-DefConst = '(' 'defconst' name:'ident' TypeAnn? Expr Documentation? ')'
+DefConst = '(' 'defconst' name:'ident' TypeAnn? Documentation? Expr ')'
 
 // Capability definition - defines a capability (access control mechanism)
 // Must have at least one expression in the body
 // Can include metadata like @event and @managed
-DefCap = '(' 'defcap' name:'ident' TypeAnn? '(' Arg* ')' Documentation? CapMeta* Expr* ')'
+DefCap = '(' 'defcap' name:'ident' TypeAnn? '(' Arg* ')' Documentation? (CapMeta | Expr)* ')'
 
 // Schema definition - defines a data structure schema (like a record type)
 DefSchema = '(' 'defschema' name:'ident' Documentation? SchemaArg* ')'
@@ -144,12 +144,15 @@ CapMeta =
 Arg = name:'ident' TypeAnn?
 SchemaArg = name:'ident' TypeAnn  // Schema field (always has a type)
 
+TypeAnn = ':' Type  // Type annotation
+
 Type =
   PrimType                        // Primitive type
 | '[' Type ']'                    // List type
-| 'module' '{' QualifiedName* '}'       // Module reference type, comma separated
-| 'ident' '{' ParsedTyName '}'    // Object/Table type
-| '*'                             // Any type (wildcard)
+| 'module' '{' QualifiedName* '}' // Module reference type, comma separated
+| 'object' '{' ParsedTyName '}'   // Schema type for objects
+| 'ident' '{' ParsedTyName '}'    // Schema type for tables
+| '*'                             // Any type (for lists)
 
 // Primitive types
 PrimType =
@@ -165,7 +168,6 @@ PrimType =
 | 'object'
 | 'table'
 
-TypeAnn = ':' Type  // Type annotation
 
 // Expressions - the core computational elements
 Expr =
@@ -185,9 +187,7 @@ Var =
 | ModRef         // Module reference (e.g., "ns::name")
 
 // Let binding - local variable definitions
-Let =
-  '(' 'let' '(' Binder* ')' Expr* ')'    // Regular let (parallel bindings)
-| '(' 'let*' '(' Binder* ')' Expr* ')'   // Sequential let (each binding sees previous ones)
+Let = '(' ('let' | 'let*') '(' Binder* ')' Expr* ')'
 
 Binder = '(' name:'ident' TypeAnn? value:Expr ')'
 

--- a/crates/syntax/src/pact.ungram
+++ b/crates/syntax/src/pact.ungram
@@ -169,16 +169,15 @@ PrimType =
 | 'table'
 
 
-// Expressions - the core computational elements
 Expr =
-  Var       // Variable reference
-| Let       // Let binding
-| Lam       // Lambda expression
-| App       // Function application
-| List      // List literal
-| Literal   // Constant/literal value
-| Object    // Object literal
-| Binding   // Binding form (for named arguments)
+  Var
+| Let
+| Lam
+| App
+| List
+| Literal
+| Object
+| Binding
 
 // Variable reference - refers to a defined name
 Var =
@@ -194,21 +193,16 @@ Binder = '(' name:'ident' TypeAnn? value:Expr ')'
 // Lambda expression - anonymous function
 Lam = '(' 'lambda' '(' Arg* ')' Expr* ')'
 
-// Function application - calling a function
-App = '(' fn:Expr args:Expr* bindings:BindingForm* ')'
+// Basic function application
+App = '(' fn:ParsedName args:Expr* ')'
 
-BindingForm = '{' BindPair* '}' // Named argument binding form: { "a" := 1, ... }
+Binding = '{' BindPair* '}' // Named argument binding form: { "a" := 1, ... }
 
-// List literal - creates a list
 // Note: In Pact, list elements can be separated by spaces or commas
 List = '[' items:Expr* ']'
 
-// Object literal - creates an object/record
 Object = '{' fields:FieldPair* '}'
 FieldPair = key:StringOrSymbol ':' value:Expr
-
-// Binding form - for named arguments and destructuring
-Binding = '{' binds:BindPair* '}' body:Expr*
 
 // Binding pair - key-value pair in a binding form
 // The key is a string or symbol, followed by := and an argument (which may have a type annotation)

--- a/crates/syntax/src/pact.ungram
+++ b/crates/syntax/src/pact.ungram
@@ -15,7 +15,7 @@ TopLevel =
 
 // Module definition - the primary organizational unit in Pact
 // Contains definitions, imports, and other declarations
-Module = '(' 'module' name:'ident' gov:Governance Documentation? ExternalDecl* Def* ')'
+Module = '(' 'module' name:'ident' gov:Governance Documentation? (ExternalDecl | Def)* ')'
 
 // Interface definition - defines a contract that modules can implement
 // Interfaces contain function signatures, constants, and schemas but no implementations
@@ -46,7 +46,7 @@ Doc = '@doc' StringLiteral
 // Model annotation for formal verification
 // Contains a list of property expressions enclosed in square brackets
 // Used to specify invariants and properties for formal verification
-Model = '@model' '[' PropertyExpr* ']'
+Model = '@model' PropList
 
 // External declarations - declarations that reference things outside the module
 // These establish relationships with other modules and interfaces
@@ -58,7 +58,7 @@ ExternalDecl =
 // Import declaration - brings definitions from other modules into scope
 // The string is an optional hash for version pinning
 // The ImportList is an optional list of specific names to import
-Use = '(' 'import' QualifiedName StringLiteral? ImportList? ')'
+Use = '(' 'use' QualifiedName StringLiteral? ImportList? ')'
 
 // Declare that this module implements an interface
 // This creates a contract that the module will provide all definitions required by the interface
@@ -82,9 +82,12 @@ Def =
 | DefTable  // Table definition - defines a database table with a schema
 | DefPact   // Pact (multi-step transaction) definition - defines a cross-chain transaction
 
-// Function definition - defines a named function with parameters and body
-// Must have at least one expression in the body
-Defun = '(' 'defun' name:'ident' TypeAnn? '(' Arg* ')' Documentation? Expr* ')'
+// List of arguments, which can be empty '()'
+Args = '(' Arg* ')'
+
+// Function definition - defines a named function with parameters and body.
+// Documentation must come first, and body must have at least one expr.
+Defun = '(' 'defun' name:'ident' TypeAnn? Args Documentation? Expr* ')'
 
 // Constant definition - defines a named constant value
 DefConst = '(' 'defconst' name:'ident' TypeAnn? Documentation? Expr ')'
@@ -92,7 +95,7 @@ DefConst = '(' 'defconst' name:'ident' TypeAnn? Documentation? Expr ')'
 // Capability definition - defines a capability (access control mechanism)
 // Must have at least one expression in the body
 // Can include metadata like @event and @managed
-DefCap = '(' 'defcap' name:'ident' TypeAnn? '(' Arg* ')' Documentation? (CapMeta | Expr)* ')'
+DefCap = '(' 'defcap' name:'ident' TypeAnn? Args Documentation? (CapMeta | Expr)* ')'
 
 // Schema definition - defines a data structure schema (like a record type)
 DefSchema = '(' 'defschema' name:'ident' Documentation? SchemaArg* ')'
@@ -102,7 +105,7 @@ DefTable = '(' 'deftable' name:'ident' ':' '{' schema:ParsedName '}' (DocString 
 
 // Pact definition - defines a multi-step transaction
 // Used for cross-chain transactions and complex multi-stage operations
-DefPact = '(' 'defpact' name:'ident' TypeAnn? '(' Arg* ')' Documentation? PactStep* ')'
+DefPact = '(' 'defpact' name:'ident' TypeAnn? Args Documentation? PactStep* ')'
 
 // Pact steps - individual steps in a multi-step transaction
 // Steps can be executed across different chains and transactions
@@ -122,22 +125,22 @@ IfDef =
 
 // Interface function definition - only signature, no implementation
 // Modules implementing the interface must provide matching implementations
-IfDefun = '(' 'defun' name:'ident' TypeAnn? '(' Arg* ')' Documentation? ')'
+IfDefun = '(' 'defun' name:'ident' TypeAnn? Args Documentation? ')'
 
 // Interface capability definition - only signature, no implementation
 // Modules implementing the interface must provide matching capability definitions
-IfDefCap = '(' 'defcap' name:'ident' TypeAnn? '(' Arg* ')' Documentation? CapMeta* ')'
+IfDefCap = '(' 'defcap' name:'ident' TypeAnn? Args Documentation? CapMeta* ')'
 
 // Interface pact definition - only signature, no implementation
 // Modules implementing the interface must provide matching pact definitions
-IfDefPact = '(' 'defpact' name:'ident' TypeAnn? '(' Arg* ')' Documentation? ')'
+IfDefPact = '(' 'defpact' name:'ident' TypeAnn? Args Documentation? ')'
 
 // Capability metadata - additional information for capabilities
 // Controls how capabilities are managed and emitted as events
 CapMeta =
   '@event' BoolLiteral?
 | '@managed'
-| '@managed' resource:ParsedName defun:'ident'
+| '@managed' resource:ParsedName fn:'ident'
 
 // Arguments - function and other parameters
 // Arg = Function argument with optional type annotation
@@ -150,8 +153,7 @@ Type =
   PrimType                        // Primitive type
 | '[' Type ']'                    // List type
 | 'module' '{' QualifiedName* '}' // Module reference type, comma separated
-| 'object' '{' ParsedTyName '}'   // Schema type for objects
-| 'ident' '{' ParsedTyName '}'    // Schema type for tables
+| 'ident' '{' ParsedTyName '}'    // Schema type for tables, objects ('ident' for object would be 'object')
 | '*'                             // Any type (for lists)
 
 // Primitive types
@@ -180,10 +182,7 @@ Expr =
 | Binding
 
 // Variable reference - refers to a defined name
-Var =
-  BareName       // Bare name (local variable or function)
-| QualifiedName  // Qualified name (from another module)
-| ModRef         // Module reference (e.g., "ns::name")
+Var = ParsedName
 
 // Let binding - local variable definitions
 Let = '(' ('let' | 'let*') '(' Binder* ')' Expr* ')'
@@ -191,7 +190,7 @@ Let = '(' ('let' | 'let*') '(' Binder* ')' Expr* ')'
 Binder = '(' name:'ident' TypeAnn? value:Expr ')'
 
 // Lambda expression - anonymous function
-Lam = '(' 'lambda' '(' Arg* ')' Expr* ')'
+Lam = '(' 'lambda' Args Expr* ')'
 
 // Basic function application
 App = '(' fn:ParsedName args:Expr* ')'
@@ -221,7 +220,7 @@ StringOrSymbol =
   StringLiteral    // Double-quoted string: "example"
 | SymbolLiteral    // Single-quoted symbol: 'example (no terminating quote)
 
-// String literal - double-quoted string
+// String literal - double-quoted string, including strings with escapes
 StringLiteral = 'string'
 
 // Symbol literal - single-quoted identifier without terminating quote
@@ -273,16 +272,15 @@ ParsedTyName =
   BareName       // Simple type name (e.g., "integer")
 | QualifiedName  // Qualified type name (e.g., "user.profile")
 
-// Property expressions - used in formal verification models
-// These form a specialized sub-language for expressing properties and invariants
 PropertyExpr =
-  ParsedName                     // Reference to a name
-| Literal                        // Literal value
-| '(' PropertyExpr* ')'          // Application of property expressions
-| '[' PropertyExpr* ']'          // List of property expressions
-| PropDefProperty                // Property definition (unique to property language)
-| PropLet                        // Let binding in property expressions
-| PropLam                        // Lambda expression in property expressions
+  Var
+| PropLet          // Let binding in property expressions (no let*)
+| PropLam          // Lambda expression in property expressions ('lam' keyword)
+| PropApp          // Application of property expressions
+| PropList         // List of property expressions
+| Literal
+| Object
+| PropDefProperty  // Property definition (unique to property language)
 
 // Let binding in property expressions - uses 'let' keyword (not 'let*')
 // Similar to Let in the main language but specific to property expressions
@@ -293,11 +291,15 @@ PropBinder = '(' name:'ident' value:PropertyExpr ')'
 
 // Lambda expression in property expressions - uses 'lam' keyword (not 'lambda')
 // Similar to Lam in the main language but specific to property expressions
-PropLam = '(' 'lam' '(' Arg* ')' PropertyExpr* ')'
+PropLam = '(' 'lam' Args PropertyExpr* ')'
+
+// Application of property expressions
+PropApp = '(' fn:ParsedName args:PropertyExpr* ')'
+
+// List of property expressions
+PropList = '[' items:PropertyExpr* ']'
 
 // Property definition - defines a named property with optional arguments
-// Example: (defproperty conserves-mass (= (column-delta token-table 'balance) 0.0))
-// Example with args: (defproperty valid-account (account:string) (and (>= (length account) 3) (<= (length account) 256)))
-PropDefProperty = '(' 'defproperty' name:'ident' args:PropArgs? body:PropertyExpr ')'
-
-PropArgs = '(' Arg* ')'
+// Unlike defun, args are entirely optional and no parens are needed; also,
+// the body is a single expression.
+PropDefProperty = '(' 'defproperty' name:'ident' args:Args? body:PropertyExpr ')'

--- a/crates/syntax/src/pact.ungram
+++ b/crates/syntax/src/pact.ungram
@@ -6,7 +6,6 @@
 
 Program = TopLevel*
 
-// For regular Pact source files
 TopLevel =
   Module      // Module definition with functions, capabilities, etc.
 | Interface   // Interface definition (similar to a module but only signatures)
@@ -192,22 +191,25 @@ Binder = '(' name:'ident' TypeAnn? value:Expr ')'
 // Lambda expression - anonymous function
 Lam = '(' 'lambda' Args Expr* ')'
 
-// Basic function application
+// Basic function application. Function must be a name, because
+// Pact does not allow exprs to return functions.
 App = '(' fn:ParsedName args:Expr* ')'
 
 Binding = '{' BindPair* '}' // Named argument binding form: { "a" := 1, ... }
 
 // Note: In Pact, list elements can be separated by spaces or commas
-List = '[' items:Expr* ']'
+// but not both, and no trailing commas allowed.
+List = '[' items:(Expr ','?)* ']'
 
+// String or symbol keys with expr values, separated by commas
 Object = '{' fields:FieldPair* '}'
-FieldPair = key:StringOrSymbol ':' value:Expr
+FieldPair = key:StringOrSymbol ':' value:Expr ','?
 
 // Binding pair - key-value pair in a binding form
-// The key is a string or symbol, followed by := and an argument (which may have a type annotation)
-BindPair = key:StringOrSymbol ':=' arg:Arg
+// The key is a string or symbol, followed by := and an argument (which may
+// have a type annotation), separated by commas.
+BindPair = key:StringOrSymbol ':=' arg:Arg ','?
 
-// Literals - actual literal values
 Literal =
   IntLiteral       // Integer literal (e.g., 42)
 | DecimalLiteral   // Decimal literal (e.g., 3.14)
@@ -237,34 +239,27 @@ BoolLiteral =
   'true'
 | 'false'
 
-// Names - references to defined entities
-// There are three types of names in Pact:
-// 1. Simple names (single identifier)
-// 2. Qualified names (dot-separated path)
-// 3. Module references (using :: operator)
-
-// A simple name - just a single identifier
-// Example: add
+// A simple name is a single identifier
 BareName = 'ident'
 
-ModQual =
-  BareName                // Simple qualifier (e.g., "module")
-| BareName '.' ModQual    // Nested qualifier (e.g., "namespace.module")
+// A potentially-qualified name, either a terminal or a path part
+DottableName =
+  'ident'
+| 'ident' '.' DottableName
 
 // A qualified name - contains at least one dot
 // In the parser, this is represented as a head and a ModQual
-// Example: my.module.function
-QualifiedName = head:BareName '.' ModQual
+QualifiedName = head:'ident' '.' DottableName
 
 // Module reference - references a name from a specific module using ::
-// Example: my.module::function
-ModRef = module:ModQual '::' name:'ident'
+// Not used for static references, so this uses 'ident' instead of 'Dottable'
+ModRef = module:'ident' '::' name:'ident'
 
 // Name reference - used in most contexts where a name is needed
 ParsedName =
   BareName       // Simple name (e.g., "add")
 | QualifiedName  // Qualified name (e.g., "math.add")
-| ModRef         // Module reference (e.g., "my.mod::name")
+| ModRef         // Module reference (e.g., "module::name")
 
 // Type name reference - used specifically for type references
 // Cannot use module references for types


### PR DESCRIPTION
A good time to pause and consider what the Ungrammar for Pact would look like, so we can use this to guide lexing and parsing decisions.