### PR TITLE
Support interfaces and more special forms

### DIFF
--- a/crates/formatter/tests/snapshot_tests/fixtures/fungible.pact
+++ b/crates/formatter/tests/snapshot_tests/fixtures/fungible.pact
@@ -1,0 +1,143 @@
+(interface fungible-v2
+
+    " Standard for fungible coins and tokens as specified in KIP-0002. "
+
+     ; ----------------------------------------------------------------------
+     ; Schema
+
+     (defschema account-details
+      @doc "Schema for results of 'account' operation."
+      @model [ (invariant (!= "" sender)) ]
+
+      account:string
+      balance:decimal
+      guard:guard)
+
+
+     ; ----------------------------------------------------------------------
+     ; Caps
+
+     (defcap TRANSFER:bool
+       ( sender:string
+         receiver:string
+         amount:decimal
+       )
+       @doc " Managed capability sealing AMOUNT for transfer from SENDER to \
+            \ RECEIVER. Permits any number of transfers up to AMOUNT."
+       @managed amount TRANSFER-mgr
+       )
+
+     (defun TRANSFER-mgr:decimal
+       ( managed:decimal
+         requested:decimal
+       )
+       @doc " Manages TRANSFER AMOUNT linearly, \
+            \ such that a request for 1.0 amount on a 3.0 \
+            \ managed quantity emits updated amount 2.0."
+       )
+
+     ; ----------------------------------------------------------------------
+     ; Functionality
+
+
+    (defun transfer:string
+      ( sender:string
+        receiver:string
+        amount:decimal
+      )
+      @doc " Transfer AMOUNT between accounts SENDER and RECEIVER. \
+           \ Fails if either SENDER or RECEIVER does not exist."
+      @model [ (property (> amount 0.0))
+               (property (!= sender ""))
+               (property (!= receiver ""))
+               (property (!= sender receiver))
+             ]
+      )
+
+     (defun transfer-create:string
+       ( sender:string
+         receiver:string
+         receiver-guard:guard
+         amount:decimal
+       )
+       @doc " Transfer AMOUNT between accounts SENDER and RECEIVER. \
+            \ Fails if SENDER does not exist. If RECEIVER exists, guard \
+            \ must match existing value. If RECEIVER does not exist, \
+            \ RECEIVER account is created using RECEIVER-GUARD. \
+            \ Subject to management by TRANSFER capability."
+       @model [ (property (> amount 0.0))
+                (property (!= sender ""))
+                (property (!= receiver ""))
+                (property (!= sender receiver))
+              ]
+       )
+
+     (defpact transfer-crosschain:string
+       ( sender:string
+         receiver:string
+         receiver-guard:guard
+         target-chain:string
+         amount:decimal
+       )
+       @doc " 2-step pact to transfer AMOUNT from SENDER on current chain \
+            \ to RECEIVER on TARGET-CHAIN via SPV proof. \
+            \ TARGET-CHAIN must be different than current chain id. \
+            \ First step debits AMOUNT coins in SENDER account and yields \
+            \ RECEIVER, RECEIVER_GUARD and AMOUNT to TARGET-CHAIN. \
+            \ Second step continuation is sent into TARGET-CHAIN with proof \
+            \ obtained from the spv 'output' endpoint of Chainweb. \
+            \ Proof is validated and RECEIVER is credited with AMOUNT \
+            \ creating account with RECEIVER_GUARD as necessary."
+       @model [ (property (> amount 0.0))
+                (property (!= sender ""))
+                (property (!= receiver ""))
+                (property (!= sender receiver))
+                (property (!= target-chain ""))
+              ]
+       )
+
+     (defun get-balance:decimal
+       ( account:string )
+       " Get balance for ACCOUNT. Fails if account does not exist."
+       )
+
+     (defun details:object{account-details}
+       ( account: string )
+       " Get an object with details of ACCOUNT. \
+       \ Fails if account does not exist."
+       )
+
+     (defun precision:integer
+       ()
+       "Return the maximum allowed decimal precision."
+       )
+
+     (defun enforce-unit:bool
+       ( amount:decimal )
+       " Enforce minimum precision allowed for transactions."
+       )
+
+     (defun create-account:string
+       ( account:string
+         guard:guard
+       )
+       " Create ACCOUNT with 0.0 balance, with GUARD controlling access."
+       )
+
+     (defun rotate:string
+       ( account:string
+         new-guard:guard
+       )
+       " Rotate guard for ACCOUNT. Transaction is validated against \
+       \ existing guard before installing new guard. "
+       )
+
+  )
+
+
+
+
+
+
+
+

--- a/crates/formatter/tests/snapshot_tests/snapshots/tests__snapshot_tests__coin.snap
+++ b/crates/formatter/tests/snapshot_tests/snapshots/tests__snapshot_tests__coin.snap
@@ -4,78 +4,82 @@ expression: "format_source(content, 80).unwrap()"
 ---
 (module coin GOVERNANCE
   @doc
-    "'coin' represents the Kadena Coin Contract. This contract provides both the     \buy/redeem gas support in the form of 'fund-tx', as well as transfer,           \credit, debit, coinbase, account creation and query, as well as SPV burn        \create. To access the coin contract, you may use its fully-qualified name,      \or issue the '(use coin)' command in the body of a module declaration."
-  
+    "'coin' represents the Kadena Coin Contract. This contract provides both the \
+    \buy/redeem gas support in the form of 'fund-tx', as well as transfer,       \
+    \credit, debit, coinbase, account creation and query, as well as SPV burn    \
+    \create. To access the coin contract, you may use its fully-qualified name,  \
+    \or issue the '(use coin)' command in the body of a module declaration."
+
   @model
     [
       (defproperty conserves-mass
         (= (column-delta coin-table 'balance) 0.0)
       )
-      
+
       (defproperty valid-account (account:string)
         (and
           (>= (length account) 3)
           (<= (length account) 256))
       )
     ]
-  
+
   (bless "ut_J_ZNkoyaPUEJhiwVeWnkSQn9JT9sQCWKdjjVVrWo")
-  
+
   (bless "1os_sLAUYvBzspn5jjawtRpJWiH1WPfhyNraeVvSIwU")
-  
+
   (bless "BjZW0T2ac6qE_I5X8GE4fal6tTqjhLTC7my0ytQSxLU")
-  
+
   (defschema coin-schema
     @doc "The coin contract token schema"
     @model [(invariant (>= balance 0.0))]
-    
+
     balance:decimal
     guard:guard
   )
-  
+
   (deftable coin-table:{coin-schema})
-  
+
   (defcap GOVERNANCE ()
     (enforce false "Enforce non-upgradeability")
   )
-  
+
   (defcap GAS ()
     "Magic capability to protect gas buy and redeem"
     true
   )
-  
+
   (defcap COINBASE ()
     "Magic capability to protect miner reward"
     true
   )
-  
+
   (defcap GENESIS ()
     "Magic capability constraining genesis transactions"
     true
   )
-  
+
   (defcap REMEDIATE ()
     "Magic capability for remediation transactions"
     true
   )
-  
+
   (defcap DEBIT (sender:string)
     "Capability for managing debiting operations"
     (enforce-guard (at 'guard (read coin-table sender)))
     (enforce (!= sender "") "valid sender")
   )
-  
+
   (defcap CREDIT (receiver:string)
     "Capability for managing crediting operations"
     (enforce (!= receiver "") "valid receiver")
   )
-  
+
   (defcap ROTATE (account:string)
     @doc "Autonomously managed capability for guard rotation"
     @managed
     true
   )
-  
+
   (defcap TRANSFER:bool
     (
       sender:string
@@ -89,21 +93,21 @@ expression: "format_source(content, 80).unwrap()"
     (compose-capability (DEBIT sender))
     (compose-capability (CREDIT receiver))
   )
-  
+
   (defun TRANSFER-mgr:decimal
     (
       managed:decimal
       requested:decimal
     )
-    
+
     (let ((newbal (- managed requested)))
-      (enforce
-        (>= newbal 0.0)
-        (format "TRANSFER exceeded for balance {}" [managed]))
+      (enforce (>= newbal 0.0)
+        (format "TRANSFER exceeded for balance {}" [managed])
+      )
       newbal
     )
   )
-  
+
   (defcap TRANSFER_XCHAIN:bool
     (
       sender:string
@@ -111,25 +115,25 @@ expression: "format_source(content, 80).unwrap()"
       amount:decimal
       target-chain:string
     )
-    
+
     @managed amount TRANSFER_XCHAIN-mgr
     (enforce-unit amount)
     (enforce (> amount 0.0) "Cross-chain transfers require a positive amount")
     (compose-capability (DEBIT sender))
   )
-  
+
   (defun TRANSFER_XCHAIN-mgr:decimal
     (
       managed:decimal
       requested:decimal
     )
-    
-    (enforce
-      (>= managed requested)
-      (format "TRANSFER_XCHAIN exceeded for balance {}" [managed]))
+
+    (enforce (>= managed requested)
+      (format "TRANSFER_XCHAIN exceeded for balance {}" [managed])
+    )
     0.0
   )
-  
+
   (defcap TRANSFER_XCHAIN_RECD:bool
     (
       sender:string
@@ -140,7 +144,7 @@ expression: "format_source(content, 80).unwrap()"
     @event
     true
   )
-  
+
   (defcap RELEASE_ALLOCATION
     (
       account:string
@@ -150,68 +154,74 @@ expression: "format_source(content, 80).unwrap()"
     @event
     true
   )
-  
+
   (defconst COIN_CHARSET CHARSET_LATIN1
     "The default coin contract character set"
   )
-  
+
   (defconst MINIMUM_PRECISION 12
     "Minimum allowed precision for coin transactions"
   )
-  
+
   (defconst MINIMUM_ACCOUNT_LENGTH 3
     "Minimum account length admissible for coin accounts"
   )
-  
+
   (defconst MAXIMUM_ACCOUNT_LENGTH 256
     "Maximum account name length admissible for coin accounts"
   )
-  
+
   (defconst VALID_CHAIN_IDS (map (int-to-str 10) (enumerate 0 19))
     "List of all valid Chainweb chain ids"
   )
-  
+
   (defun enforce-unit:bool (amount:decimal)
     @doc "Enforce minimum precision allowed for coin transactions"
-    
+
     (enforce
       (=
         (floor amount MINIMUM_PRECISION)
         amount)
-      (format "Amount violates minimum precision: {}" [amount]))
+      (format "Amount violates minimum precision: {}" [amount])
+    )
   )
-  
+
   (defun validate-account (account:string)
     @doc
-      "Enforce that an account name conforms to the coin contract            \minimum and maximum length requirements, as well as the               \latin-1 character set."
-    
+      "Enforce that an account name conforms to the coin contract \
+           \minimum and maximum length requirements, as well as the    \
+           \latin-1 character set."
+
     (enforce
       (is-charset COIN_CHARSET account)
       (format
         "Account does not conform to the coin contract charset: {}"
-        [account]))
-    
+        [account])
+    )
+
     (let ((account-length (length account)))
-      
+
       (enforce
         (>= account-length MINIMUM_ACCOUNT_LENGTH)
         (format
           "Account name does not conform to the min length requirement: {}"
-          [account]))
-      
+          [account])
+      )
+
       (enforce
         (<= account-length MAXIMUM_ACCOUNT_LENGTH)
         (format
           "Account name does not conform to the max length requirement: {}"
-          [account]))
+          [account])
+      )
     )
   )
-  
+
   (defun gas-only ()
     "Predicate for gas-only user guards."
     (require-capability (GAS))
   )
-  
+
   (defun gas-guard (guard:guard)
     "Predicate for gas + single key user guards"
     (enforce-one
@@ -221,93 +231,98 @@ expression: "format_source(content, 80).unwrap()"
         (enforce-guard guard)
       ])
   )
-  
+
   (defun buy-gas:string (sender:string total:decimal)
     @doc
-      "This function describes the main 'gas buy' operation. At this point       \MINER has been chosen from the pool, and will be validated. The SENDER         \of this transaction has specified a gas limit LIMIT (maximum gas) for          	he transaction, and the price is the spot price of gas at that time.          \The gas buy will be executed prior to executing SENDER's code."
-    
+      "This function describes the main 'gas buy' operation. At this point \
+      \MINER has been chosen from the pool, and will be validated. The SENDER   \
+      \of this transaction has specified a gas limit LIMIT (maximum gas) for    \
+      \the transaction, and the price is the spot price of gas at that time.    \
+      \The gas buy will be executed prior to executing SENDER's code."
+
     @model
       [
         (property (> total 0.0))
         (property (valid-account sender))
       ]
-    
+
     (validate-account sender)
-    
+
     (enforce-unit total)
     (enforce (> total 0.0) "gas supply must be a positive quantity")
-    
+
     (require-capability (GAS))
-    (with-capability
-      (DEBIT sender)
-      (debit sender total))
+    (with-capability (DEBIT sender)
+      (debit sender total)
+    )
   )
-  
+
   (defun redeem-gas:string
     (miner:string miner-guard:guard sender:string total:decimal)
     @doc
-      "This function describes the main 'redeem gas' operation. At this          \point, the SENDER's transaction has been executed, and the gas that            \was charged has been calculated. MINER will be credited the gas cost,          \and SENDER will receive the remainder up to the limit"
-    
+      "This function describes the main 'redeem gas' operation. At this    \
+      \point, the SENDER's transaction has been executed, and the gas that      \
+      \was charged has been calculated. MINER will be credited the gas cost,    \
+      \and SENDER will receive the remainder up to the limit"
+
     @model
       [
         (property (> total 0.0))
         (property (valid-account sender))
         (property (valid-account miner))
       ]
-    
+
     (validate-account sender)
     (validate-account miner)
     (enforce-unit total)
-    
+
     (require-capability (GAS))
     (let*
       (
         (fee (read-decimal "fee"))
         (refund (- total fee))
       )
-      
+
       (enforce-unit fee)
-      (enforce
-        (>= fee 0.0)
-        "fee must be a non-negative quantity")
-      
-      (enforce
-        (>= refund 0.0)
-        "refund must be a non-negative quantity")
-      
+      (enforce (>= fee 0.0)
+        "fee must be a non-negative quantity"
+      )
+
+      (enforce (>= refund 0.0)
+        "refund must be a non-negative quantity"
+      )
+
       (emit-event (TRANSFER sender miner fee))
-      
-      (with-capability
-        (CREDIT sender)
+
+      (with-capability (CREDIT sender)
         (if (> refund 0.0)
-          (with-read
-            coin-table
-            sender
+          (with-read coin-table sender
             {"balance" := balance}
-            (update
-              coin-table
-              sender
-              {"balance": (+ balance refund)}))
-          
+            (update coin-table sender
+              {"balance": (+ balance refund)}
+            )
+          )
+
           "noop"
-        ))
-      
-      (with-capability
-        (CREDIT miner)
+        )
+      )
+
+      (with-capability (CREDIT miner)
         (if (> fee 0.0)
           (credit miner miner-guard fee)
           "noop"
-        ))
+        )
+      )
     )
-  
+
   )
-  
+
   (defun create-account:string (account:string guard:guard)
     @model [(property (valid-account account))]
-    
+
     (validate-account account)
     (enforce-reserved account guard)
-    
+
     (insert
       coin-table
       account
@@ -316,47 +331,41 @@ expression: "format_source(content, 80).unwrap()"
         "guard": guard
       })
   )
-  
+
   (defun get-balance:decimal (account:string)
-    (with-read
-      coin-table
-      account
+    (with-read coin-table account
       {"balance" := balance}
       balance
     )
   )
-  
+
   (defun details:object
     (account:string)
-    (with-read
-      coin-table
-      account
+    (with-read coin-table account
       {"balance" := bal, "guard" := g}
-      {"account": account, "balance": bal, "guard": g})
+      {"account": account, "balance": bal, "guard": g}
+    )
   )
-  
+
   (defun rotate:string (account:string new-guard:guard)
-    (with-capability
-      (ROTATE account)
-      (with-read
-        coin-table
-        account
+    (with-capability (ROTATE account)
+      (with-read coin-table account
         {"guard" := old-guard}
-        
+
         (enforce-guard old-guard)
-        
-        (update
-          coin-table
-          account
+
+        (update coin-table account
           {"guard": new-guard}
-        )))
+        )
+      )
+    )
   )
-  
+
   (defun precision:integer
     ()
     MINIMUM_PRECISION
   )
-  
+
   (defun transfer:string (sender:string receiver:string amount:decimal)
     @model
       [
@@ -366,32 +375,30 @@ expression: "format_source(content, 80).unwrap()"
         (property (valid-account receiver))
         (property (!= sender receiver))
       ]
-    
-    (enforce
-      (!= sender receiver)
-      "sender cannot be the receiver of a transfer")
-    
+
+    (enforce (!= sender receiver)
+      "sender cannot be the receiver of a transfer"
+    )
+
     (validate-account sender)
     (validate-account receiver)
-    
-    (enforce
-      (> amount 0.0)
-      "transfer amount must be positive")
-    
+
+    (enforce (> amount 0.0)
+      "transfer amount must be positive"
+    )
+
     (enforce-unit amount)
-    
-    (with-capability
-      (TRANSFER sender receiver amount)
+
+    (with-capability (TRANSFER sender receiver amount)
       (debit sender amount)
-      (with-read
-        coin-table
-        receiver
+      (with-read coin-table receiver
         {"guard" := g}
-        
-        (credit receiver g amount))
+
+        (credit receiver g amount)
+      )
     )
   )
-  
+
   (defun transfer-create:string
     (
       sender:string
@@ -399,152 +406,153 @@ expression: "format_source(content, 80).unwrap()"
       receiver-guard:guard
       amount:decimal
     )
-    
+
     @model [(property conserves-mass)]
-    
-    (enforce
-      (!= sender receiver)
-      "sender cannot be the receiver of a transfer")
-    
+
+    (enforce (!= sender receiver)
+      "sender cannot be the receiver of a transfer"
+    )
+
     (validate-account sender)
     (validate-account receiver)
-    
-    (enforce
-      (> amount 0.0)
-      "transfer amount must be positive")
-    
+
+    (enforce (> amount 0.0)
+      "transfer amount must be positive"
+    )
+
     (enforce-unit amount)
-    
-    (with-capability
-      (TRANSFER sender receiver amount)
+
+    (with-capability (TRANSFER sender receiver amount)
       (debit sender amount)
-      (credit receiver receiver-guard amount))
+      (credit receiver receiver-guard amount)
+    )
   )
-  
+
   (defun coinbase:string (account:string account-guard:guard amount:decimal)
     @doc
-      "Internal function for the initial creation of coins.  This function       \cannot be used outside of the coin contract."
-    
+      "Internal function for the initial creation of coins.  This function \
+      \cannot be used outside of the coin contract."
+
     @model
       [
         (property (valid-account account))
         (property (> amount 0.0))
       ]
-    
+
     (validate-account account)
     (enforce-unit amount)
-    
+
     (require-capability (COINBASE))
     (emit-event (TRANSFER "" account amount))
-    (with-capability
-      (CREDIT account)
-      (credit account account-guard amount))
+    (with-capability (CREDIT account)
+      (credit account account-guard amount)
+    )
   )
-  
+
   (defun remediate:string (account:string amount:decimal)
     @doc
-      "Allows for remediation transactions. This function            \is protected by the REMEDIATE capability"
+      "Allows for remediation transactions. This function \
+           \is protected by the REMEDIATE capability"
     @model
       [
         (property (valid-account account))
         (property (> amount 0.0))
       ]
-    
+
     (validate-account account)
-    
-    (enforce
-      (> amount 0.0)
-      "Remediation amount must be positive")
-    
+
+    (enforce (> amount 0.0)
+      "Remediation amount must be positive"
+    )
+
     (enforce-unit amount)
-    
+
     (require-capability (REMEDIATE))
     (emit-event (TRANSFER "" account amount))
-    (with-read
-      coin-table
-      account
+    (with-read coin-table account
       {"balance" := balance}
-      
+
       (enforce (<= amount balance) "Insufficient funds")
-      
-      (update
-        coin-table
-        account
+
+      (update coin-table account
         {"balance": (- balance amount)}
-      ))
+      )
+    )
   )
-  
+
   (defpact fund-tx (sender:string miner:string miner-guard:guard total:decimal)
     @doc
-      "'fund-tx' is a special pact to fund a transaction in two steps,           \with the actual transaction transpiring in the middle:                         \                                                                               \  1) A buying phase, debiting the sender for total gas and fee, yielding       \     TX_MAX_CHARGE.                                                            \  2) A settlement phase, resuming TX_MAX_CHARGE, and allocating to the         \     coinbase account for used gas and fee, and sender account for bal-        \     ance (unused gas, if any)."
-    
+      "'fund-tx' is a special pact to fund a transaction in two steps,     \
+      \with the actual transaction transpiring in the middle:                   \
+      \                                                                         \
+      \  1) A buying phase, debiting the sender for total gas and fee, yielding \
+      \     TX_MAX_CHARGE.                                                      \
+      \  2) A settlement phase, resuming TX_MAX_CHARGE, and allocating to the   \
+      \     coinbase account for used gas and fee, and sender account for bal-  \
+      \     ance (unused gas, if any)."
+
     @model
       [
         (property (> total 0.0))
         (property (valid-account sender))
         (property (valid-account miner))
       ]
-    
+
     (step (buy-gas sender total))
     (step (redeem-gas miner miner-guard sender total))
   )
-  
+
   (defun debit:string (account:string amount:decimal)
     @doc "Debit AMOUNT from ACCOUNT balance"
-    
+
     @model
       [
         (property (> amount 0.0))
         (property (valid-account account))
       ]
-    
+
     (validate-account account)
-    
-    (enforce
-      (> amount 0.0)
-      "debit amount must be positive")
-    
+
+    (enforce (> amount 0.0)
+      "debit amount must be positive"
+    )
+
     (enforce-unit amount)
-    
+
     (require-capability (DEBIT account))
-    (with-read
-      coin-table
-      account
+    (with-read coin-table account
       {"balance" := balance}
-      
+
       (enforce (<= amount balance) "Insufficient funds")
-      
-      (update
-        coin-table
-        account
+
+      (update coin-table account
         {"balance": (- balance amount)}
-      ))
+      )
+    )
   )
-  
+
   (defun credit:string (account:string guard:guard amount:decimal)
     @doc "Credit AMOUNT to ACCOUNT balance"
-    
+
     @model
       [
         (property (> amount 0.0))
         (property (valid-account account))
       ]
-    
+
     (validate-account account)
-    
+
     (enforce (> amount 0.0) "credit amount must be positive")
     (enforce-unit amount)
-    
+
     (require-capability (CREDIT account))
-    (with-default-read
-      coin-table
-      account
+    (with-default-read coin-table account
       {"balance": -1.0, "guard": guard}
       {"balance" := balance, "guard" := retg}
-      (enforce
-        (= retg guard)
-        "account guards do not match")
-      
+      (enforce (= retg guard)
+        "account guards do not match"
+      )
+
       (let
         (
           (is-new
@@ -553,25 +561,26 @@ expression: "format_source(content, 80).unwrap()"
               false
             ))
         )
-        
-        (write
-          coin-table
-          account
+
+        (write coin-table account
           {
             "balance": (if is-new amount (+ balance amount)),
             "guard": retg
-          })
+          }
+        )
       )
     )
   )
-  
+
   (defun check-reserved:string (account:string)
-    " Checks ACCOUNT for reserved name and returns type if       \ found or empty string. Reserved names start with a       \ single char and colon, e.g. 'c:foo', which would return 'c' as type."
+    " Checks ACCOUNT for reserved name and returns type if \
+      \ found or empty string. Reserved names start with a \
+      \ single char and colon, e.g. 'c:foo', which would return 'c' as type."
     (let ((pfx (take 2 account)))
       (if (= ":" (take -1 pfx)) (take 1 pfx) "")
     )
   )
-  
+
   (defun enforce-reserved:bool (account:string guard:guard)
     @doc "Enforce reserved account name protocols."
     (if (validate-principal guard account)
@@ -581,15 +590,15 @@ expression: "format_source(content, 80).unwrap()"
           true
           (if (= r "k")
             (enforce false "Single-key account protocol violation")
-            (enforce
-              false
-              (format "Reserved protocol guard violation: {}" [r]))
+            (enforce false
+              (format "Reserved protocol guard violation: {}" [r])
+            )
           )
         )
       )
     )
   )
-  
+
   (defschema crosschain-schema
     @doc "Schema for yielded value in cross-chain transfers"
     receiver:string
@@ -597,7 +606,7 @@ expression: "format_source(content, 80).unwrap()"
     amount:decimal
     source-chain:string
   )
-  
+
   (defpact transfer-crosschain:string
     (
       sender:string
@@ -606,39 +615,39 @@ expression: "format_source(content, 80).unwrap()"
       target-chain:string
       amount:decimal
     )
-    
+
     @model
       [
         (property (> amount 0.0))
         (property (valid-account sender))
         (property (valid-account receiver))
       ]
-    
+
     (step
       (with-capability
         (TRANSFER_XCHAIN sender receiver amount target-chain)
-        
+
         (validate-account sender)
         (validate-account receiver)
-        
+
         (enforce (!= "" target-chain) "empty target-chain")
-        (enforce
-          (!= (at 'chain-id (chain-data)) target-chain)
-          "cannot run cross-chain transfers to the same chain")
-        
-        (enforce
-          (> amount 0.0)
-          "transfer quantity must be positive")
-        
+        (enforce (!= (at 'chain-id (chain-data)) target-chain)
+          "cannot run cross-chain transfers to the same chain"
+        )
+
+        (enforce (> amount 0.0)
+          "transfer quantity must be positive"
+        )
+
         (enforce-unit amount)
-        
-        (enforce
-          (contains target-chain VALID_CHAIN_IDS)
-          "target chain is not a valid chainweb chain id")
-        
+
+        (enforce (contains target-chain VALID_CHAIN_IDS)
+          "target chain is not a valid chainweb chain id"
+        )
+
         (debit sender amount)
         (emit-event (TRANSFER sender "" amount))
-        
+
         (let
           (
             (crosschain-details:object{crosschain-schema}
@@ -650,8 +659,9 @@ expression: "format_source(content, 80).unwrap()"
               })
           )
           (yield crosschain-details target-chain)
-        )))
-    
+        )
+      ))
+
     (step
       (resume
         {
@@ -660,27 +670,27 @@ expression: "format_source(content, 80).unwrap()"
           "amount" := amount,
           "source-chain" := source-chain
         }
-        
+
         (emit-event (TRANSFER "" receiver amount))
         (emit-event (TRANSFER_XCHAIN_RECD "" receiver amount source-chain))
-        
-        (with-capability
-          (CREDIT receiver)
-          (credit receiver receiver-guard amount))
+
+        (with-capability (CREDIT receiver)
+          (credit receiver receiver-guard amount)
+        )
       ))
   )
-  
+
   (defschema allocation-schema
     @doc "Genesis allocation registry"
-    
+
     balance:decimal
     date:time
     guard:guard
     redeemed:bool
   )
-  
+
   (deftable allocation-table:{allocation-schema})
-  
+
   (defun create-allocation-account
     (
       account:string
@@ -688,26 +698,28 @@ expression: "format_source(content, 80).unwrap()"
       keyset-ref:string
       amount:decimal
     )
-    
+
     @doc
-      "Add an entry to the coin allocation table. This function            \also creates a corresponding empty coin contract account            \of the same name and guard. Requires GENESIS capability. "
-    
+      "Add an entry to the coin allocation table. This function \
+           \also creates a corresponding empty coin contract account \
+           \of the same name and guard. Requires GENESIS capability. "
+
     @model [(property (valid-account account))]
-    
+
     (require-capability (GENESIS))
-    
+
     (validate-account account)
-    (enforce
-      (>= amount 0.0)
-      "allocation amount must be non-negative")
-    
+    (enforce (>= amount 0.0)
+      "allocation amount must be non-negative"
+    )
+
     (enforce-unit amount)
-    
+
     (let
       ((guard:guard (keyset-ref-guard keyset-ref)))
-      
+
       (create-account account guard)
-      
+
       (insert
         allocation-table
         account
@@ -719,58 +731,59 @@ expression: "format_source(content, 80).unwrap()"
         })
     )
   )
-  
+
   (defun release-allocation
     (account:string)
-    
+
     @doc
-      "Release funds associated with allocation ACCOUNT into main ledger.              \ACCOUNT must already exist in main ledger. Allocation is deactivated            \after release."
+      "Release funds associated with allocation ACCOUNT into main ledger.   \
+           \ACCOUNT must already exist in main ledger. Allocation is deactivated \
+           \after release."
     @model [(property (valid-account account))]
-    
+
     (validate-account account)
-    
-    (with-read
-      allocation-table
-      account
+
+    (with-read allocation-table account
       {
         "balance" := balance,
         "date" := release-time,
         "redeemed" := redeemed,
         "guard" := guard
       }
-      
+
       (let ((curr-time:time (at 'block-time (chain-data))))
-        
-        (enforce
-          (not redeemed)
-          "allocation funds have already been redeemed")
-        
+
+        (enforce (not redeemed)
+          "allocation funds have already been redeemed"
+        )
+
         (enforce
           (>= curr-time release-time)
           (format
             "funds locked until {}. current time: {}"
-            [release-time curr-time]))
-        
-        (with-capability
-          (RELEASE_ALLOCATION account balance)
-          
+            [release-time curr-time])
+        )
+
+        (with-capability (RELEASE_ALLOCATION account balance)
+
           (enforce-guard guard)
-          
-          (with-capability
-            (CREDIT account)
+
+          (with-capability (CREDIT account)
             (emit-event (TRANSFER "" account balance))
             (credit account guard balance)
-            
-            (update
-              allocation-table
-              account
+
+            (update allocation-table account
               {
                 "redeemed": true,
                 "balance": 0.0
-              })
-            
-            "Allocation successfully released to main ledger"))
-      ))
+              }
+            )
+
+            "Allocation successfully released to main ledger"
+          )
+        )
+      )
+    )
   )
 
 )

--- a/crates/formatter/tests/snapshot_tests/snapshots/tests__snapshot_tests__fungible.snap
+++ b/crates/formatter/tests/snapshot_tests/snapshots/tests__snapshot_tests__fungible.snap
@@ -1,0 +1,156 @@
+---
+source: crates/formatter/tests/snapshot_tests/mod.rs
+expression: "format_source(content, 80).unwrap()"
+---
+(interface fungible-v2
+
+  " Standard for fungible coins and tokens as specified in KIP-0002. "
+
+  ; ----------------------------------------------------------------------
+  ; Schema
+
+  (defschema account-details
+    @doc "Schema for results of 'account' operation."
+    @model [(invariant (!= "" sender))]
+
+    account:string
+    balance:decimal
+    guard:guard
+  )
+
+  ; ----------------------------------------------------------------------
+  ; Caps
+
+  (defcap TRANSFER:bool
+    (
+      sender:string
+      receiver:string
+      amount:decimal
+    )
+    @doc
+      " Managed capability sealing AMOUNT for transfer from SENDER to \
+            \ RECEIVER. Permits any number of transfers up to AMOUNT."
+    @managed amount TRANSFER-mgr
+  )
+
+  (defun TRANSFER-mgr:decimal
+    (
+      managed:decimal
+      requested:decimal
+    )
+    @doc
+      " Manages TRANSFER AMOUNT linearly, \
+            \ such that a request for 1.0 amount on a 3.0 \
+            \ managed quantity emits updated amount 2.0."
+  )
+
+  ; ----------------------------------------------------------------------
+  ; Functionality
+
+  (defun transfer:string
+    (
+      sender:string
+      receiver:string
+      amount:decimal
+    )
+    @doc
+      " Transfer AMOUNT between accounts SENDER and RECEIVER. \
+           \ Fails if either SENDER or RECEIVER does not exist."
+    @model
+      [
+        (property (> amount 0.0))
+        (property (!= sender ""))
+        (property (!= receiver ""))
+        (property (!= sender receiver))
+      ]
+  )
+
+  (defun transfer-create:string
+    (
+      sender:string
+      receiver:string
+      receiver-guard:guard
+      amount:decimal
+    )
+    @doc
+      " Transfer AMOUNT between accounts SENDER and RECEIVER. \
+            \ Fails if SENDER does not exist. If RECEIVER exists, guard \
+            \ must match existing value. If RECEIVER does not exist, \
+            \ RECEIVER account is created using RECEIVER-GUARD. \
+            \ Subject to management by TRANSFER capability."
+    @model
+      [
+        (property (> amount 0.0))
+        (property (!= sender ""))
+        (property (!= receiver ""))
+        (property (!= sender receiver))
+      ]
+  )
+
+  (defpact transfer-crosschain:string
+    (
+      sender:string
+      receiver:string
+      receiver-guard:guard
+      target-chain:string
+      amount:decimal
+    )
+    @doc
+      " 2-step pact to transfer AMOUNT from SENDER on current chain \
+            \ to RECEIVER on TARGET-CHAIN via SPV proof. \
+            \ TARGET-CHAIN must be different than current chain id. \
+            \ First step debits AMOUNT coins in SENDER account and yields \
+            \ RECEIVER, RECEIVER_GUARD and AMOUNT to TARGET-CHAIN. \
+            \ Second step continuation is sent into TARGET-CHAIN with proof \
+            \ obtained from the spv 'output' endpoint of Chainweb. \
+            \ Proof is validated and RECEIVER is credited with AMOUNT \
+            \ creating account with RECEIVER_GUARD as necessary."
+    @model
+      [
+        (property (> amount 0.0))
+        (property (!= sender ""))
+        (property (!= receiver ""))
+        (property (!= sender receiver))
+        (property (!= target-chain ""))
+      ]
+  )
+
+  (defun get-balance:decimal
+    (account:string)
+    " Get balance for ACCOUNT. Fails if account does not exist."
+  )
+
+  (defun details:object{account-details}
+    (account:string)
+    " Get an object with details of ACCOUNT. \
+       \ Fails if account does not exist."
+  )
+
+  (defun precision:integer
+    ()
+    "Return the maximum allowed decimal precision."
+  )
+
+  (defun enforce-unit:bool
+    (amount:decimal)
+    " Enforce minimum precision allowed for transactions."
+  )
+
+  (defun create-account:string
+    (
+      account:string
+      guard:guard
+    )
+    " Create ACCOUNT with 0.0 balance, with GUARD controlling access."
+  )
+
+  (defun rotate:string
+    (
+      account:string
+      new-guard:guard
+    )
+    " Rotate guard for ACCOUNT. Transaction is validated against \
+       \ existing guard before installing new guard. "
+  )
+
+)

--- a/crates/formatter/tests/snapshot_tests/snapshots/tests__snapshot_tests__let.snap
+++ b/crates/formatter/tests/snapshot_tests/snapshots/tests__snapshot_tests__let.snap
@@ -5,25 +5,24 @@ expression: "format_source(content, 80).unwrap()"
 (module test GOV
   (defun testfn ()
     (let ((newbal (- managed requested)))
-      (enforce
-        (>= newbal 0.0)
-        (format "TRANSFER exceeded for balance {}" [managed]))
+      (enforce (>= newbal 0.0)
+        (format "TRANSFER exceeded for balance {}" [managed])
+      )
       newbal
     )
-    
+
     (let ((pfx (take 2 account)))
       (if (= ":" (take -1 pfx)) (take 1 pfx) "")
     )
-    
+
     (let ((is-new (if (= balance -1.0) (enforce-reserved account guard) false)))
-      
-      (write
-        coin-table
-        account
+
+      (write coin-table account
         {
           "balance": (if is-new amount (+ balance amount)),
           "guard": retg
-        })
+        }
+      )
     )
   )
 

--- a/crates/formatter/tests/snapshot_tests/snapshots/tests__snapshot_tests__model.snap
+++ b/crates/formatter/tests/snapshot_tests/snapshots/tests__snapshot_tests__model.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/formatter/tests/snapshot_tests/mod.rs
-expression: "format_source(content, 60).unwrap()"
+expression: "format_source(content, 80).unwrap()"
 ---
 (module my-mod GOV
   @model
@@ -8,13 +8,13 @@ expression: "format_source(content, 60).unwrap()"
       (defproperty conserves-mass
         (= (column-delta coin-table 'balance) 0.0)
       )
-      
+
       (defproperty valid-account (account:string)
         (and
           (>= (length account) 3)
           (<= (length account) 256))
       )
     ]
-  
+
   (defcap GOV () true)
 )

--- a/crates/formatter/tests/snapshot_tests/snapshots/tests__snapshot_tests__module.snap
+++ b/crates/formatter/tests/snapshot_tests/snapshots/tests__snapshot_tests__module.snap
@@ -4,7 +4,7 @@ expression: "format_source(content, 80).unwrap()"
 ---
 (module my-mod GOV
   (defcap GOV () true)
-  
+
   (defun wot:integer
     (
       a:string
@@ -15,7 +15,7 @@ expression: "format_source(content, 80).unwrap()"
     @model []
     (+ 1 b)
   )
-  
+
   (defun wot2:[[integer]] (a b)
     [
       1,

--- a/crates/syntax/src/lexer.rs
+++ b/crates/syntax/src/lexer.rs
@@ -287,9 +287,7 @@ impl<'a> Lexer<'a> {
     }
 
     /// Scan a string literal. Strings can be multi-line using a backslash as a
-    /// line continuation. NOTE: We currently remove the continuation, in keeping
-    /// with the Pact lexer, but we may need to preserve it if it is important
-    /// for formatting.
+    /// line continuation.
     fn scan_string_content(&mut self) -> String {
         let mut result = String::new();
 
@@ -297,55 +295,6 @@ impl<'a> Lexer<'a> {
             if ch == '"' {
                 self.advance();
                 break;
-            } else if ch == '\\' {
-                self.advance();
-
-                match self.current {
-                    Some('\n') => {
-                        // This is a line continuation - skip both the backslash and newline
-                        self.advance();
-                    }
-                    Some(' ') => {
-                        // Check if this is a line continuation with space between backslashes
-                        self.advance(); // consume the space
-                        if let Some('\\') = self.current {
-                            self.advance(); // consume the second backslash
-                            if let Some('\n') = self.current {
-                                self.advance(); // consume the newline
-                            }
-                        } else {
-                            // Not a line continuation, preserve the backslash and space
-                            result.push('\\');
-                            result.push(' ');
-                        }
-                    }
-                    Some('n') => {
-                        result.push('\n');
-                        self.advance();
-                    }
-                    Some('t') => {
-                        result.push('\t');
-                        self.advance();
-                    }
-                    Some('"') => {
-                        result.push('"');
-                        self.advance();
-                    }
-                    Some('\'') => {
-                        result.push('\'');
-                        self.advance();
-                    }
-                    Some(ch) => {
-                        // For any other escaped character, preserve both the backslash and the character
-                        result.push('\\');
-                        result.push(ch);
-                        self.advance();
-                    }
-                    None => {
-                        // Unterminated string
-                        result.push('\\');
-                    }
-                }
             } else {
                 result.push(ch);
                 self.advance();

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -95,21 +95,20 @@ pub enum TokenKind {
 pub enum TreeKind {
     // Top-level structure
     TopLevel,
+    Interface,
 
     // Module and interface structures
     Module,
-    Interface,
     DocAnn,
     ModelAnn,
     EventAnn,
     ManagedAnn,
 
     // External declarations
-    ExternalDecl,
-    Use,
+    Import,
     ImportList,
-    Implements,
     Bless,
+    Implements,
 
     // Definitions
     ParamList,
@@ -174,6 +173,14 @@ pub enum TreeKind {
 
     // Additional nodes we treat specially
     If,
+    Cond,
+    CondBranch,
+    WithCapability,
+    WithDefaultRead,
+    WithRead,
+    Update,
+    Enforce,
+    Write,
 
     // Error node
     ErrorTree,

--- a/crates/syntax/tests/integration_tests/mod.rs
+++ b/crates/syntax/tests/integration_tests/mod.rs
@@ -129,24 +129,30 @@ fn format_tokens_for_comparison(tokens: &[SourceToken]) -> Vec<String> {
             // Literals
             TokenKind::Ident => format!("ident<{}>", token.text),
             TokenKind::Number => format!("number<{}>", token.text),
-            TokenKind::String => format!("\"{}\"", token.text.trim_matches('"')),
+            TokenKind::String => format!("\"{}\"", filter_escapes(token.text.trim_matches('"'))),
             TokenKind::Symbol => format!("'{}", token.text.trim_start_matches('\'')),
             TokenKind::Bool => token.text.clone(),
-
-            // Keywords not reserved in the Pact lexer, but reserved in the parser
-            // TokenKind::WithCapabilityKeyword => "ident<with-capability>".to_string(),
-            // TokenKind::WithReadKeyword => "ident<with-read>".to_string(),
-            // TokenKind::WithDefaultReadKeyword => "ident<with-default-read>".to_string(),
-            // TokenKind::EnforceKeyword => "ident<enforce>".to_string(),
-            // TokenKind::IfKeyword => "ident<if>".to_string(),
-            // TokenKind::CondKeyword => "ident<cond>".to_string(),
-            // TokenKind::DoKeyword => "ident<do>".to_string(),
 
             // Special tokens
             TokenKind::Eof => "eof".to_string(),
             TokenKind::Error => format!("error<{}>", token.text),
         })
         .collect()
+}
+
+// The Pact lexer trims out escape sequences, but we have them in our lexer.
+fn filter_escapes(text: &str) -> String {
+    let mut result = String::new();
+    let chars: Vec<char> = text.chars().collect();
+    let mut inside_backslash_pair = false;
+    for c in chars {
+        if c == '\\' {
+            inside_backslash_pair = !inside_backslash_pair;
+        } else if !inside_backslash_pair {
+            result.push(c);
+        }
+    }
+    result
 }
 
 /// Extract the first output section from the Pact lexer debug output


### PR DESCRIPTION
I _think_ this now covers the whole language in parsing. We also do a few new things:

* I've added more forms as 'special forms' despite not technically being builtins as far as lexing is concerned, because they're commonly formatted in specific ways (`cond`, `if`, `enforce`, `with-capability`, and so on).
* I've added support for 'raw' nodes for things we don't want to format. This is in preparation for formatting error nodes.
* I've added a post-processing step that trims trailing spaces from repeated newlines because, alas, the `pretty` library doesn't handle this appropriately.