### PR TITLE
Improve docstring support

### DIFF
--- a/crates/formatter/src/format_doc.rs
+++ b/crates/formatter/src/format_doc.rs
@@ -410,6 +410,12 @@ where
         })
     }
 
+    /// Joins with a hardline
+    pub fn join_hardline(self, other: Self) -> Self {
+        let allocator = self.doc.0;
+        join_docs(self, other, |_, doc| allocator.hardline().append(doc))
+    }
+
     pub fn group(self) -> Self {
         Self {
             doc: self.doc.group(),

--- a/crates/formatter/tests/snapshot_tests/snapshots/tests__snapshot_tests__coin.snap
+++ b/crates/formatter/tests/snapshot_tests/snapshots/tests__snapshot_tests__coin.snap
@@ -189,8 +189,8 @@ expression: "format_source(content, 80).unwrap()"
   (defun validate-account (account:string)
     @doc
       "Enforce that an account name conforms to the coin contract \
-           \minimum and maximum length requirements, as well as the    \
-           \latin-1 character set."
+      \minimum and maximum length requirements, as well as the    \
+      \latin-1 character set."
 
     (enforce
       (is-charset COIN_CHARSET account)
@@ -452,7 +452,7 @@ expression: "format_source(content, 80).unwrap()"
   (defun remediate:string (account:string amount:decimal)
     @doc
       "Allows for remediation transactions. This function \
-           \is protected by the REMEDIATE capability"
+      \is protected by the REMEDIATE capability"
     @model
       [
         (property (valid-account account))
@@ -574,8 +574,8 @@ expression: "format_source(content, 80).unwrap()"
 
   (defun check-reserved:string (account:string)
     " Checks ACCOUNT for reserved name and returns type if \
-      \ found or empty string. Reserved names start with a \
-      \ single char and colon, e.g. 'c:foo', which would return 'c' as type."
+    \ found or empty string. Reserved names start with a \
+    \ single char and colon, e.g. 'c:foo', which would return 'c' as type."
     (let ((pfx (take 2 account)))
       (if (= ":" (take -1 pfx)) (take 1 pfx) "")
     )
@@ -701,8 +701,8 @@ expression: "format_source(content, 80).unwrap()"
 
     @doc
       "Add an entry to the coin allocation table. This function \
-           \also creates a corresponding empty coin contract account \
-           \of the same name and guard. Requires GENESIS capability. "
+      \also creates a corresponding empty coin contract account \
+      \of the same name and guard. Requires GENESIS capability. "
 
     @model [(property (valid-account account))]
 
@@ -737,8 +737,8 @@ expression: "format_source(content, 80).unwrap()"
 
     @doc
       "Release funds associated with allocation ACCOUNT into main ledger.   \
-           \ACCOUNT must already exist in main ledger. Allocation is deactivated \
-           \after release."
+      \ACCOUNT must already exist in main ledger. Allocation is deactivated \
+      \after release."
     @model [(property (valid-account account))]
 
     (validate-account account)

--- a/crates/formatter/tests/snapshot_tests/snapshots/tests__snapshot_tests__fungible.snap
+++ b/crates/formatter/tests/snapshot_tests/snapshots/tests__snapshot_tests__fungible.snap
@@ -29,7 +29,7 @@ expression: "format_source(content, 80).unwrap()"
     )
     @doc
       " Managed capability sealing AMOUNT for transfer from SENDER to \
-            \ RECEIVER. Permits any number of transfers up to AMOUNT."
+      \ RECEIVER. Permits any number of transfers up to AMOUNT."
     @managed amount TRANSFER-mgr
   )
 
@@ -40,8 +40,8 @@ expression: "format_source(content, 80).unwrap()"
     )
     @doc
       " Manages TRANSFER AMOUNT linearly, \
-            \ such that a request for 1.0 amount on a 3.0 \
-            \ managed quantity emits updated amount 2.0."
+      \ such that a request for 1.0 amount on a 3.0 \
+      \ managed quantity emits updated amount 2.0."
   )
 
   ; ----------------------------------------------------------------------
@@ -55,7 +55,7 @@ expression: "format_source(content, 80).unwrap()"
     )
     @doc
       " Transfer AMOUNT between accounts SENDER and RECEIVER. \
-           \ Fails if either SENDER or RECEIVER does not exist."
+      \ Fails if either SENDER or RECEIVER does not exist."
     @model
       [
         (property (> amount 0.0))
@@ -74,10 +74,10 @@ expression: "format_source(content, 80).unwrap()"
     )
     @doc
       " Transfer AMOUNT between accounts SENDER and RECEIVER. \
-            \ Fails if SENDER does not exist. If RECEIVER exists, guard \
-            \ must match existing value. If RECEIVER does not exist, \
-            \ RECEIVER account is created using RECEIVER-GUARD. \
-            \ Subject to management by TRANSFER capability."
+      \ Fails if SENDER does not exist. If RECEIVER exists, guard \
+      \ must match existing value. If RECEIVER does not exist, \
+      \ RECEIVER account is created using RECEIVER-GUARD. \
+      \ Subject to management by TRANSFER capability."
     @model
       [
         (property (> amount 0.0))
@@ -97,14 +97,14 @@ expression: "format_source(content, 80).unwrap()"
     )
     @doc
       " 2-step pact to transfer AMOUNT from SENDER on current chain \
-            \ to RECEIVER on TARGET-CHAIN via SPV proof. \
-            \ TARGET-CHAIN must be different than current chain id. \
-            \ First step debits AMOUNT coins in SENDER account and yields \
-            \ RECEIVER, RECEIVER_GUARD and AMOUNT to TARGET-CHAIN. \
-            \ Second step continuation is sent into TARGET-CHAIN with proof \
-            \ obtained from the spv 'output' endpoint of Chainweb. \
-            \ Proof is validated and RECEIVER is credited with AMOUNT \
-            \ creating account with RECEIVER_GUARD as necessary."
+      \ to RECEIVER on TARGET-CHAIN via SPV proof. \
+      \ TARGET-CHAIN must be different than current chain id. \
+      \ First step debits AMOUNT coins in SENDER account and yields \
+      \ RECEIVER, RECEIVER_GUARD and AMOUNT to TARGET-CHAIN. \
+      \ Second step continuation is sent into TARGET-CHAIN with proof \
+      \ obtained from the spv 'output' endpoint of Chainweb. \
+      \ Proof is validated and RECEIVER is credited with AMOUNT \
+      \ creating account with RECEIVER_GUARD as necessary."
     @model
       [
         (property (> amount 0.0))
@@ -123,7 +123,7 @@ expression: "format_source(content, 80).unwrap()"
   (defun details:object{account-details}
     (account:string)
     " Get an object with details of ACCOUNT. \
-       \ Fails if account does not exist."
+    \ Fails if account does not exist."
   )
 
   (defun precision:integer
@@ -150,7 +150,7 @@ expression: "format_source(content, 80).unwrap()"
       new-guard:guard
     )
     " Rotate guard for ACCOUNT. Transaction is validated against \
-       \ existing guard before installing new guard. "
+    \ existing guard before installing new guard. "
   )
 
 )

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -158,6 +158,7 @@ pub enum TreeKind {
     // Literals
     IntLiteral,
     DecimalLiteral,
+    MultilineString,
 
     // Names
     Name,


### PR DESCRIPTION
Existing docstrings were problematic because we formatted them according to the user's exact input string. However, if the first line of the multiline string has changed in indentation, then subsequent lines will be too far or too little indented because they respect the _original_ indentation. We now split multiline strings and trim off shared indentation, such that the result will line up according to the new formatter indentation.