### PR TITLE
Add wasm generation and doc site

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "bumpalo"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +190,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
 name = "once_cell"
 version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +208,15 @@ dependencies = [
  "clap",
  "formatter",
  "syntax",
+]
+
+[[package]]
+name = "pactfmt-docs"
+version = "0.1.0"
+dependencies = [
+ "formatter",
+ "syntax",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -250,6 +277,12 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "similar"
@@ -322,6 +355,64 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,10 @@
 [workspace]
-members = ["crates/formatter", "crates/syntax", "crates/test-utils"]
+members = [
+    "crates/formatter",
+    "crates/syntax",
+    "crates/test-utils",
+    "docs/src/wasm",
+]
 
 [package]
 name = "pactfmt"

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>pactfmt</title>
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 20px;
+    }
+    .container {
+      display: flex;
+      gap: 20px;
+    }
+    .pane {
+      flex: 1;
+    }
+    textarea {
+      width: 100%;
+      height: 400px;
+      font-family: monospace;
+      padding: 8px;
+      box-sizing: border-box;
+      resize: vertical;
+    }
+    h2 {
+      margin-top: 0;
+    }
+  </style>
+</head>
+<body>
+  <h1>pactfmt</h1>
+
+  <div class="container">
+    <div class="pane">
+      <h2>Input</h2>
+      <textarea id="input" placeholder="Type something to format..."></textarea>
+    </div>
+    <div class="pane">
+      <h2>Formatted Output</h2>
+      <textarea id="output" readonly></textarea>
+    </div>
+  </div>
+
+  <script type="module">
+    import init, { format } from './pkg/pactfmt_docs.js';
+
+    let initialized = false;
+    const inputTextarea = document.getElementById('input');
+    const outputTextarea = document.getElementById('output');
+
+    async function initWasm() {
+      try {
+        await init();
+        initialized = true;
+        if (inputTextarea.value) {
+          formatText();
+        }
+      } catch (error) {
+        console.error('Failed to initialize WASM:', error);
+        outputTextarea.value = 'Error initializing WASM: ' + error.message;
+      }
+    }
+
+    function formatText() {
+      if (!initialized) {
+        outputTextarea.value = 'WASM module not initialized yet';
+        return;
+      }
+
+      if (inputTextarea.value.trim() !== '') {
+        try {
+          const formatted = format(inputTextarea.value);
+          outputTextarea.value = formatted;
+        } catch (error) {
+          console.error('Format error:', error);
+          outputTextarea.value = 'Error: ' + error.message;
+        }
+      } else {
+        outputTextarea.value = '';
+      }
+    }
+
+    initWasm();
+
+    let timeout;
+    inputTextarea.addEventListener('keyup', () => {
+      clearTimeout(timeout);
+      timeout = setTimeout(formatText, 300);
+    });
+  </script>
+</body>
+</html>

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "docs",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "build": "cd src/wasm && wasm-pack build --target web --out-dir ../../pkg",
+    "start": "npx serve ."
+  }
+}

--- a/docs/src/wasm/Cargo.toml
+++ b/docs/src/wasm/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "pactfmt-docs"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wasm-bindgen = "0.2.84"
+formatter = { path = "../../../crates/formatter" }
+syntax = { path = "../../../crates/syntax" }

--- a/docs/src/wasm/src/lib.rs
+++ b/docs/src/wasm/src/lib.rs
@@ -1,0 +1,11 @@
+use formatter::format_source;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn format(source: &str) -> String {
+    let src = format_source(source, 80);
+    match src {
+        Err(err) => err,
+        Ok(formatted) => formatted,
+    }
+}


### PR DESCRIPTION
Adds a demo site that uses the formatter via web assembly to let users try it out. In the future we should add:

* compressed contents of input text in the URL for easy sharing
* show the lexed, parsed, and formatted outputs, depending on your selections
* automatically build the docs site and publish via CI